### PR TITLE
feat(gocheok-project): Radix Dialog 기반 커스텀 Select

### DIFF
--- a/.cursor/commands/pull-request.mdc
+++ b/.cursor/commands/pull-request.mdc
@@ -6,6 +6,7 @@ alwaysApply: false
 
 # Pull Request
 
+한글로 작성
 PR 초안·리뷰 요청 문구를 작성할 때는 `.github/pull_request_template.md`의 섹션 순서와 항목을 채운다.
 
 ## 제목

--- a/packages/gocheok-project/package.json
+++ b/packages/gocheok-project/package.json
@@ -11,8 +11,14 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@radix-ui/react-dialog": "^1.1.15"
+  },
   "dependencies": {
     "@gsap/react": "^2.1.2",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@tailwindcss/vite": "catalog:tailwindcss",
     "gsap": "^3.13.0",
     "react": "catalog:react",
@@ -37,6 +43,7 @@
     "@types/react-dom": "catalog:react",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^10.1.0",
+    "eslint-plugin-storybook": "10.3.4",
     "mbc-eslint": "workspace:*",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.12",
@@ -44,7 +51,6 @@
     "storybook": "^10.3.4",
     "vite": "^5.4.1",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.1.3",
-    "eslint-plugin-storybook": "10.3.4"
+    "vitest": "^3.1.3"
   }
 }

--- a/packages/gocheok-project/src/components/forms/select/Select.stories.tsx
+++ b/packages/gocheok-project/src/components/forms/select/Select.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Label } from '@gocheok/components/forms/label/Label';
 import { Select } from '@gocheok/components/forms/select/Select';
+import { SelectItem } from './SelectItem';
 
 const meta: Meta<typeof Select> = {
   title: 'Forms/Select/Default',
@@ -20,17 +21,16 @@ type Story = StoryObj<typeof Select>;
 
 const sampleOptions = (
   <>
-    <option value="">선택하세요</option>
-    <option value="a">옵션 A</option>
-    <option value="b">옵션 B</option>
-    <option value="c">옵션 C</option>
+    <SelectItem value="a">옵션 A</SelectItem>
+    <SelectItem value="b">옵션 B</SelectItem>
+    <SelectItem value="c">옵션 C</SelectItem>
   </>
 );
 
 export const Default: Story = {
   render: () => (
     <div className="max-w-xs">
-      <Select defaultValue="">{sampleOptions}</Select>
+      <Select value="a">{sampleOptions}</Select>
     </div>
   ),
 };

--- a/packages/gocheok-project/src/components/forms/select/Select.tsx
+++ b/packages/gocheok-project/src/components/forms/select/Select.tsx
@@ -1,13 +1,65 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useLayoutEffect, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+import { SelectProvider, useSelectContext } from '@gocheok/components/forms/select/SelectContext';
+import { SelectDialog } from '@gocheok/components/forms/select/SelectDialog';
 
-export const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  ({ className, disabled, children, ...props }, ref) => {
-    return (
-      <select
-        ref={ref}
+export type SelectProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+type SelectInnerProps = SelectProps & {
+  forwardedRef: React.ForwardedRef<HTMLButtonElement>;
+};
+
+function SelectInner({
+  className,
+  disabled,
+  children,
+  value: valueFromParent,
+  forwardedRef,
+  ...props
+}: SelectInnerProps) {
+  const { state, dispatch } = useSelectContext();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const setButtonRef = (node: HTMLButtonElement | null) => {
+    buttonRef.current = node;
+    if (typeof forwardedRef === 'function') {
+      forwardedRef(node);
+    } else if (forwardedRef != null) {
+      // React ref 객체는 런타임에서만 갱신 (props 재할당이 아님)
+      // eslint-disable-next-line react-hooks/immutability -- ref 병합 관례
+      forwardedRef.current = node;
+    }
+  };
+
+  const prevPropValue = useRef(valueFromParent);
+
+  const handleClick = () => {
+    if (disabled) return;
+    dispatch({ type: 'SET_OPEN', open: !state.isOpen });
+  };
+
+  useEffect(() => {
+    if (valueFromParent === prevPropValue.current) return;
+    prevPropValue.current = valueFromParent;
+    dispatch({ type: 'SET_VALUE', value: String(valueFromParent ?? '') });
+  }, [valueFromParent, dispatch]);
+
+  useLayoutEffect(() => {
+    if (!state.isOpen || !buttonRef.current) return;
+    const { x, y, height } = buttonRef.current.getBoundingClientRect();
+    const MARGIN = 4;
+    dispatch({
+      type: 'SET_DIALOG_POSITION',
+      position: { x: x + MARGIN, y: y + height + MARGIN },
+    });
+  }, [state.isOpen, dispatch]);
+
+  return (
+    <div>
+      <button
+        ref={setButtonRef}
+        type="button"
         className={twMerge(
           'w-full cursor-pointer appearance-none rounded-md border border-gray-300 bg-(--color-background) bg-[length:1rem_1rem] bg-[right_0.75rem_center] bg-no-repeat px-4 py-2 pr-10 text-(--color-foreground) disabled:cursor-not-allowed',
           "bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2020%2020%22%3E%3Cpath%20stroke%3D%22%236b7684%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%221.5%22%20d%3D%22m6%208%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')]",
@@ -15,10 +67,32 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           className,
         )}
         disabled={disabled}
+        onClick={handleClick}
         {...props}
       >
-        {children}
-      </select>
+        {state.value}
+      </button>
+      <SelectDialog>
+        <div className="flex flex-col">{children}</div>
+      </SelectDialog>
+    </div>
+  );
+}
+
+export const Select = forwardRef<HTMLButtonElement, SelectProps>(
+  ({ className, disabled, children, value = '', ...props }, ref) => {
+    return (
+      <SelectProvider defaultValue={String(value)}>
+        <SelectInner
+          className={className}
+          disabled={disabled}
+          value={value}
+          forwardedRef={ref}
+          {...props}
+        >
+          {children}
+        </SelectInner>
+      </SelectProvider>
     );
   },
 );

--- a/packages/gocheok-project/src/components/forms/select/Select.tsx
+++ b/packages/gocheok-project/src/components/forms/select/Select.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, useEffect, useLayoutEffect, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 

--- a/packages/gocheok-project/src/components/forms/select/SelectContext.tsx
+++ b/packages/gocheok-project/src/components/forms/select/SelectContext.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useMemo, useReducer } from 'react';
+
+import type { PopupPixelPosition } from '@gocheok/components/forms/select/types';
+
+export type SelectState = {
+  value: string;
+  dialogPosition: PopupPixelPosition | null;
+  isOpen: boolean;
+};
+
+export type SelectAction =
+  | { type: 'SET_VALUE'; value: string }
+  | { type: 'SET_DIALOG_POSITION'; position: PopupPixelPosition | null }
+  | { type: 'SET_OPEN'; open: boolean };
+
+function createInitialState(defaultValue: string): SelectState {
+  return {
+    value: defaultValue,
+    dialogPosition: null,
+    isOpen: false,
+  };
+}
+
+const selectReducer = (state: SelectState, action: SelectAction): SelectState => {
+  switch (action.type) {
+    case 'SET_VALUE':
+      return { ...state, value: action.value };
+    case 'SET_DIALOG_POSITION':
+      return { ...state, dialogPosition: action.position };
+    case 'SET_OPEN':
+      return { ...state, isOpen: action.open };
+    default:
+      return state;
+  }
+};
+
+export type SelectContextValue = {
+  state: SelectState;
+  dispatch: React.Dispatch<SelectAction>;
+};
+export type SelectProviderProps = React.PropsWithChildren<{
+  defaultValue?: string;
+}>;
+
+const SelectContext = createContext<SelectContextValue | null>(null);
+
+export const SelectProvider = ({ children, defaultValue = '' }: SelectProviderProps) => {
+  const [state, dispatch] = useReducer(selectReducer, defaultValue, (dv) => createInitialState(dv));
+  const contextValue = useMemo(() => ({ state, dispatch }), [state, dispatch]);
+
+  return <SelectContext.Provider value={contextValue}>{children}</SelectContext.Provider>;
+};
+
+export const useSelectContext = (): SelectContextValue => {
+  const ctx = useContext(SelectContext);
+  if (ctx == null) {
+    throw new Error('useSelectContext는 SelectProvider 트리 안에서만 사용할 수 있습니다.');
+  }
+  return ctx;
+};

--- a/packages/gocheok-project/src/components/forms/select/SelectDialog.tsx
+++ b/packages/gocheok-project/src/components/forms/select/SelectDialog.tsx
@@ -22,14 +22,15 @@ export const SelectDialog = ({ children }: SelectDialogProps) => {
         <Dialog.Overlay
           data-state={state.isOpen ? 'open' : 'closed'}
           className={twMerge(
-            'animate-overlayShow 300ms cubic-bezier(0.16, 1, 0.3, 1) pointer-events-none fixed inset-0 z-200',
-            'data-[state=open]:animate-overlayShow data-[state=closed]:animate-overlayHide',
+            'pointer-events-none fixed inset-0 z-200',
+            'data-[state=closed]:animate-overlay-hide data-[state=open]:animate-overlay-show',
             isMobile && 'pointer-events-auto bg-black/50',
           )}
         />
         <Dialog.Content
           className={twMerge(
-            'max-w-440px animate-contentShow 300ms cubic-bezier(0.16, 1, 0.3, 1) fixed z-201 transform overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none',
+            'max-w-440px fixed z-201 transform overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none',
+            'data-[state=closed]:animate-select-dialog-out data-[state=open]:animate-select-dialog-in',
             isMobile && 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
           )}
           style={

--- a/packages/gocheok-project/src/components/forms/select/SelectDialog.tsx
+++ b/packages/gocheok-project/src/components/forms/select/SelectDialog.tsx
@@ -1,0 +1,46 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { twMerge } from 'tailwind-merge';
+
+import { useSelectContext } from '@gocheok/components/forms/select/SelectContext';
+
+type SelectDialogProps = {
+  children: React.ReactNode;
+};
+
+export const SelectDialog = ({ children }: SelectDialogProps) => {
+  const { state, dispatch } = useSelectContext();
+  const isMobile = window.innerWidth < 768;
+  const position = state.dialogPosition;
+
+  const handleOpenChange = (open: boolean) => {
+    dispatch({ type: 'SET_OPEN', open });
+  };
+
+  return (
+    <Dialog.Root open={state.isOpen} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          data-state={state.isOpen ? 'open' : 'closed'}
+          className={twMerge(
+            'animate-overlayShow 300ms cubic-bezier(0.16, 1, 0.3, 1) pointer-events-none fixed inset-0 z-200',
+            'data-[state=open]:animate-overlayShow data-[state=closed]:animate-overlayHide',
+            isMobile && 'pointer-events-auto bg-black/50',
+          )}
+        />
+        <Dialog.Content
+          className={twMerge(
+            'max-w-440px animate-contentShow 300ms cubic-bezier(0.16, 1, 0.3, 1) fixed z-201 transform overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none',
+            isMobile && 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
+          )}
+          style={
+            !isMobile && position
+              ? { top: position.y, left: position.x, transform: 'none' }
+              : undefined
+          }
+        >
+          {children}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/packages/gocheok-project/src/components/forms/select/SelectItem.tsx
+++ b/packages/gocheok-project/src/components/forms/select/SelectItem.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { useSelectContext } from '@gocheok/components/forms/select/SelectContext';
+
+export const SelectItem = ({
+  className,
+  children,
+  value,
+  onClick,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+  const { state, dispatch } = useSelectContext();
+  const isSelected = state.value === value;
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (value === undefined || value === null) return;
+
+    dispatch({ type: 'SET_VALUE', value: String(value) });
+    dispatch({ type: 'SET_OPEN', open: false });
+    onClick?.(e);
+  };
+
+  return (
+    <button
+      type="button"
+      className={twMerge(
+        'w-full cursor-pointer px-4 py-2',
+        'first:rounded-t-md last:rounded-b-md',
+        'border-b border-gray-200 last:border-b-0 hover:bg-gray-100 hover:text-black',
+        isSelected && 'bg-(--color-primary) text-(--color-neutral-100)',
+        className,
+      )}
+      value={value}
+      onClick={handleClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};

--- a/packages/gocheok-project/src/components/forms/select/index.ts
+++ b/packages/gocheok-project/src/components/forms/select/index.ts
@@ -1,3 +1,1 @@
 export * from '@gocheok/components/forms/select/Select';
-export * from '@gocheok/components/forms/select/SelectContext';
-export * from '@gocheok/components/forms/select/SelectDialog';

--- a/packages/gocheok-project/src/components/forms/select/index.ts
+++ b/packages/gocheok-project/src/components/forms/select/index.ts
@@ -1,1 +1,3 @@
 export * from '@gocheok/components/forms/select/Select';
+export * from '@gocheok/components/forms/select/SelectContext';
+export * from '@gocheok/components/forms/select/SelectDialog';

--- a/packages/gocheok-project/src/components/forms/select/types.ts
+++ b/packages/gocheok-project/src/components/forms/select/types.ts
@@ -1,0 +1,4 @@
+export interface PopupPixelPosition {
+  x: number;
+  y: number;
+}

--- a/packages/gocheok-project/src/tailwind.css
+++ b/packages/gocheok-project/src/tailwind.css
@@ -250,6 +250,9 @@ menu {
   --animate-overlay-show: overlay-show 0.2s ease-out;
   --animate-overlay-hide: overlay-hide 0.2s ease-out;
   --animate-content-show: content-show 0.2s ease-out;
+  --animate-select-dialog-in: select-dialog-in 0.2s
+    cubic-bezier(0.16, 1, 0.3, 1);
+  --animate-select-dialog-out: select-dialog-out 0.15s ease-in;
   --animate-my-animation: my-keyframes 1s infinite alternate;
   --animate-checkbox-check: checkbox-check-pop 0.35s
     cubic-bezier(0.34, 1.2, 0.64, 1);
@@ -278,6 +281,22 @@ menu {
     to {
       opacity: 1;
       transform: translate(-50%, -50%) scale(1);
+    }
+  }
+  @keyframes select-dialog-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes select-dialog-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
     }
   }
   @keyframes my-keyframes {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,9 @@ importers:
       '@gsap/react':
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.13.0)(react@19.2.0)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tailwindcss/vite':
         specifier: catalog:tailwindcss
         version: 4.1.10(vite@5.4.19(@types/node@24.10.1)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.44.1))
@@ -13058,7 +13061,7 @@ snapshots:
       '@typescript-eslint/parser': 8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.29.0(jiti@2.6.1))
@@ -13102,7 +13105,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -13127,14 +13130,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -13185,7 +13188,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## 요약
`gocheok-project`에 reducer 기반 Context와 Radix Dialog를 사용한 커스텀 Select를 추가합니다.

## 변경 사항
- **SelectContext**: `useReducer`로 선택 값, 다이얼로그 앵커 좌표, 열림 상태를 공유합니다.
- **SelectDialog / SelectItem**: Radix Dialog로 옵션 패널을 표시하고, 항목 선택 시 값을 갱신한 뒤 패널을 닫습니다.
- **스타일**: 패널에 `overflow-hidden`과 첫·마지막 항목 라운드를 적용해 배경이 모서리를 덮지 않도록 했습니다.
- **애니메이션**: 오버레이는 `animate-overlay-show/hide`, 콘텐츠는 `transform` 없이 opacity만 바꾸는 `select-dialog-in/out`을 사용합니다 (데스크톱 앵커 배치와 충돌하지 않음).
- **의존성**: `@radix-ui/react-dialog`를 peer 및 dependencies에 추가했습니다.

## 참고
`gocheok-project`를 쓰는 앱에서는 peer를 맞추기 위해 `@radix-ui/react-dialog`를 직접 dependencies에 선언하는 것이 좋습니다.