### PR TITLE
feat(gocheok-project): 테이블 컴포넌트, React 19 ref, tsbuildinfo gitignore

### DIFF
--- a/.cursor/rules/gocheok-project.mdc
+++ b/.cursor/rules/gocheok-project.mdc
@@ -21,4 +21,5 @@ globs:
 - **컴포넌트 배치:** `src/components/` 아래 도메인 폴더(`actions`, `presenter`, `layout`, `navigation` 등)에 맞춰 추가·수정한다.
 - **import:** `src/` 내부에서는 상대 경로(`../`) 대신 `@gocheok/...` 절대 경로를 쓴다(예: `@gocheok/components/actions/button/Button`, `@gocheok/App`). 패키지 `tsconfig`의 `@gocheok/*`·`vite`의 `@gocheok` alias, 소비 앱(예: portfolio)의 `paths`에 동일 접두사를 맞춘다.
 - **스타일:** 유틸리티 클래스 우선, 변형은 기존 컴포넌트와 같이 `cva` 패턴을 재사용한다. 테마 값·토큰은 임의 값 남용 없이 맞춘다.
+- **React 19:** 함수 컴포넌트에 DOM `ref`는 **`ref`를 일반 prop**으로 받는다 (`forwardRef` 지양). props 타입에 `ref?: React.Ref<해당 HTMLElement>`를 명시한다.
 - **문서:** 스토리 파일은 `*.stories.tsx` 네이밍과 기존 스토리 구조를 따른다.

--- a/.cursor/rules/react.mdc
+++ b/.cursor/rules/react.mdc
@@ -12,6 +12,11 @@ alwaysApply: false
 - **Hooks:** Call hooks at the top level of the component, before any conditional logic or return statements.
 - **Imports:** Order imports: React -> external libraries -> internal modules/components -> assets/styles.
 
+## Refs (React 19+)
+
+- Prefer **`ref` as a normal prop** on function components; avoid `forwardRef` unless legacy interop requires it.
+- Type the prop explicitly (e.g. `ref?: React.Ref<HTMLButtonElement>`) alongside other props; when extending DOM attribute types that already declare `ref`, use `Omit<..., 'ref'>` before intersecting your props if TypeScript reports a conflict.
+
 ## State Management
 
 - **Simple State:** Use `useState` for simple, local component state.

--- a/packages/gocheok-project/.gitignore
+++ b/packages/gocheok-project/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 storybook-static
+*.tsbuildinfo
 *.local
 
 # Editor directories and files

--- a/packages/gocheok-project/index.ts
+++ b/packages/gocheok-project/index.ts
@@ -5,6 +5,7 @@ export * from './src/components/actions/buttonContainer';
 
 // layout
 export * from './src/components/layout/divider';
+export * from './src/components/layout/table';
 
 // navigation
 export * from './src/components/navigation/header';

--- a/packages/gocheok-project/src/components/layout/table/Table.stories.tsx
+++ b/packages/gocheok-project/src/components/layout/table/Table.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@gocheok/components/layout/table';
+
+const meta: Meta<typeof Table> = {
+  title: 'Layout/Table/Default',
+  component: Table,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-3xl p-6 text-(--color-foreground)">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Table>;
+
+export const Default: Story = {
+  render: () => (
+    <Table>
+      <TableCaption>최근 주문 목록</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>주문번호</TableHead>
+          <TableHead>상품</TableHead>
+          <TableHead align="right">금액</TableHead>
+          <TableHead>상태</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell className="font-medium">#1024</TableCell>
+          <TableCell>티켓 A</TableCell>
+          <TableCell align="right" className="tabular-nums">
+            ₩45,000
+          </TableCell>
+          <TableCell>결제완료</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell className="font-medium">#1025</TableCell>
+          <TableCell>티켓 B</TableCell>
+          <TableCell align="right" className="tabular-nums">
+            ₩32,000
+          </TableCell>
+          <TableCell>배송중</TableCell>
+        </TableRow>
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={2}>합계</TableCell>
+          <TableCell align="right" className="tabular-nums">
+            ₩77,000
+          </TableCell>
+          <TableCell />
+        </TableRow>
+      </TableFooter>
+    </Table>
+  ),
+};
+
+export const Dense: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="h-9 py-2">항목</TableHead>
+          <TableHead className="h-9 py-2">값</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell className="py-2">구역</TableCell>
+          <TableCell className="py-2">A구역</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell className="py-2">좌석</TableCell>
+          <TableCell className="py-2">12열 8번</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  ),
+};

--- a/packages/gocheok-project/src/components/layout/table/Table.tsx
+++ b/packages/gocheok-project/src/components/layout/table/Table.tsx
@@ -1,0 +1,22 @@
+import type { HTMLAttributes, Ref } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+export type TableProps = HTMLAttributes<HTMLTableElement> & {
+  ref?: Ref<HTMLTableElement>;
+};
+
+export function Table({ className, ref, ...props }: TableProps) {
+  return (
+    <div className="relative w-full overflow-x-auto rounded-lg border border-(--color-border)">
+      <table
+        ref={ref}
+        className={twMerge(
+          'w-full caption-bottom border-collapse text-sm text-(--color-foreground)',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/packages/gocheok-project/src/components/layout/table/TableBody.tsx
+++ b/packages/gocheok-project/src/components/layout/table/TableBody.tsx
@@ -1,0 +1,13 @@
+import type { HTMLAttributes, Ref } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+export type TableBodyProps = HTMLAttributes<HTMLTableSectionElement> & {
+  ref?: Ref<HTMLTableSectionElement>;
+};
+
+export function TableBody({ className, ref, ...props }: TableBodyProps) {
+  return (
+    <tbody ref={ref} className={twMerge('[&_tr:last-child]:border-0', className)} {...props} />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/table/TableCaption.tsx
+++ b/packages/gocheok-project/src/components/layout/table/TableCaption.tsx
@@ -1,0 +1,17 @@
+import type { HTMLAttributes, Ref } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+export type TableCaptionProps = HTMLAttributes<HTMLTableCaptionElement> & {
+  ref?: Ref<HTMLTableCaptionElement>;
+};
+
+export function TableCaption({ className, ref, ...props }: TableCaptionProps) {
+  return (
+    <caption
+      ref={ref}
+      className={twMerge('my-2 text-sm text-(--color-grey-600)', className)}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/table/TableCell.tsx
+++ b/packages/gocheok-project/src/components/layout/table/TableCell.tsx
@@ -1,0 +1,28 @@
+import type { Ref, TdHTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+import {
+  TABLE_CELL_ALIGN_CLASS,
+  type TableCellAlign,
+} from '@gocheok/components/layout/table/types';
+
+export type TableCellProps = Omit<TdHTMLAttributes<HTMLTableCellElement>, 'align'> & {
+  /** 셀 텍스트 정렬. 기본값은 `left`. */
+  align?: TableCellAlign;
+  ref?: Ref<HTMLTableCellElement>;
+};
+
+export function TableCell({ className, align = 'left', ref, ...props }: TableCellProps) {
+  return (
+    <td
+      ref={ref}
+      className={twMerge(
+        'px-4 py-3 align-middle [&:has([role=checkbox])]:pr-0',
+        TABLE_CELL_ALIGN_CLASS[align],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/table/TableFooter.tsx
+++ b/packages/gocheok-project/src/components/layout/table/TableFooter.tsx
@@ -1,0 +1,20 @@
+import type { HTMLAttributes, Ref } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+export type TableFooterProps = HTMLAttributes<HTMLTableSectionElement> & {
+  ref?: Ref<HTMLTableSectionElement>;
+};
+
+export function TableFooter({ className, ref, ...props }: TableFooterProps) {
+  return (
+    <tfoot
+      ref={ref}
+      className={twMerge(
+        'border-t border-(--color-border) bg-(--color-grey-100) font-medium [&>tr]:last:border-b-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/table/TableHead.tsx
+++ b/packages/gocheok-project/src/components/layout/table/TableHead.tsx
@@ -1,0 +1,28 @@
+import type { Ref, ThHTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+import {
+  TABLE_CELL_ALIGN_CLASS,
+  type TableCellAlign,
+} from '@gocheok/components/layout/table/types';
+
+export type TableHeadProps = Omit<ThHTMLAttributes<HTMLTableCellElement>, 'align'> & {
+  /** 셀 텍스트 정렬. 기본값은 `left`. */
+  align?: TableCellAlign;
+  ref?: Ref<HTMLTableCellElement>;
+};
+
+export function TableHead({ className, align = 'left', ref, ...props }: TableHeadProps) {
+  return (
+    <th
+      ref={ref}
+      className={twMerge(
+        'h-10 px-4 align-middle font-bold text-(--color-grey-800) [&:has([role=checkbox])]:pr-0',
+        TABLE_CELL_ALIGN_CLASS[align],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/table/TableHeader.tsx
+++ b/packages/gocheok-project/src/components/layout/table/TableHeader.tsx
@@ -1,0 +1,20 @@
+import type { HTMLAttributes, Ref } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+export type TableHeaderProps = HTMLAttributes<HTMLTableSectionElement> & {
+  ref?: Ref<HTMLTableSectionElement>;
+};
+
+export function TableHeader({ className, ref, ...props }: TableHeaderProps) {
+  return (
+    <thead
+      ref={ref}
+      className={twMerge(
+        'bg-(--color-grey-100) [&_tr]:border-b [&_tr]:border-(--color-border)',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/table/TableRow.tsx
+++ b/packages/gocheok-project/src/components/layout/table/TableRow.tsx
@@ -1,0 +1,20 @@
+import type { HTMLAttributes, Ref } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+export type TableRowProps = HTMLAttributes<HTMLTableRowElement> & {
+  ref?: Ref<HTMLTableRowElement>;
+};
+
+export function TableRow({ className, ref, ...props }: TableRowProps) {
+  return (
+    <tr
+      ref={ref}
+      className={twMerge(
+        'border-b border-(--color-border) transition-colors hover:bg-(--color-grey-50)',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/table/index.ts
+++ b/packages/gocheok-project/src/components/layout/table/index.ts
@@ -1,0 +1,9 @@
+export * from '@gocheok/components/layout/table/Table';
+export * from '@gocheok/components/layout/table/TableBody';
+export * from '@gocheok/components/layout/table/TableCaption';
+export * from '@gocheok/components/layout/table/TableCell';
+export * from '@gocheok/components/layout/table/TableFooter';
+export * from '@gocheok/components/layout/table/TableHead';
+export * from '@gocheok/components/layout/table/TableHeader';
+export * from '@gocheok/components/layout/table/TableRow';
+export type { TableCellAlign } from '@gocheok/components/layout/table/types';

--- a/packages/gocheok-project/src/components/layout/table/types.ts
+++ b/packages/gocheok-project/src/components/layout/table/types.ts
@@ -1,0 +1,7 @@
+export type TableCellAlign = 'left' | 'center' | 'right';
+
+export const TABLE_CELL_ALIGN_CLASS: Record<TableCellAlign, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+};


### PR DESCRIPTION
## 요약

- `layout/table`에 테이블 관련 컴포넌트(Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableCaption)와 Storybook 스토리를 추가했습니다.
- TableHead·TableCell에서 `align`(`left` | `center` | `right`)을 지원하며, 공유 타입은 `types.ts`에 둡니다.
- React 19 방식으로 `ref`를 일반 prop으로 받으며 `forwardRef`는 사용하지 않습니다.
- 동일 내용을 `.cursor/rules/gocheok-project.mdc`, `.cursor/rules/react.mdc`에 반영했습니다.
- `packages/gocheok-project`에서 `*.tsbuildinfo`를 gitignore합니다.

## 커밋

- feat(gocheok-project): 테이블 컴포넌트 및 React 19 ref 규칙
- chore(gocheok-project): tsbuildinfo를 gitignore에 추가
