### PR TITLE
feat(gocheok-project): add layout and display primitives

### DIFF
--- a/packages/gocheok-project/index.ts
+++ b/packages/gocheok-project/index.ts
@@ -4,7 +4,11 @@ export * from './src/components/actions/button';
 export * from './src/components/actions/buttonContainer';
 
 // layout
+export * from './src/components/layout/container';
 export * from './src/components/layout/divider';
+export * from './src/components/layout/flex';
+export * from './src/components/layout/grid';
+export * from './src/components/layout/stack';
 export * from './src/components/layout/table';
 
 // navigation
@@ -20,6 +24,9 @@ export * from './src/components/forms/switch';
 export * from './src/components/forms/select';
 
 // presenter
+export * from './src/components/presenter/avatar';
+export * from './src/components/presenter/badge';
+export * from './src/components/presenter/card';
 export * from './src/components/presenter/chip';
 export * from './src/components/presenter/typography';
 export * from './src/components/presenter/profile';

--- a/packages/gocheok-project/src/components/layout/container/Container.stories.tsx
+++ b/packages/gocheok-project/src/components/layout/container/Container.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Card } from '@gocheok/components/presenter/card/Card';
+import { Container } from '@gocheok/components/layout/container/Container';
+import { Stack } from '@gocheok/components/layout/stack/Stack';
+
+const meta: Meta<typeof Container> = {
+  title: 'Layout/Container/Default',
+  component: Container,
+  decorators: [
+    (Story) => (
+      <div className="w-full bg-(--color-grey-50) py-6 text-(--color-foreground)">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Container>;
+
+export const Default: Story = {
+  render: () => (
+    <Container size="md">
+      <Card>
+        <Stack gap="sm">
+          <strong className="text-lg">콘텐츠 영역</strong>
+          <p className="text-sm text-(--color-grey-600)">
+            Container는 페이지 폭과 좌우 여백을 토큰 기준으로 맞출 때 사용합니다.
+          </p>
+        </Stack>
+      </Card>
+    </Container>
+  ),
+};
+
+export const FullWidth: Story = {
+  render: () => (
+    <Container size="full" padding="lg">
+      <Card tone="muted">
+        <p className="text-sm text-(--color-grey-700)">
+          전체 폭 레이아웃에서도 동일한 패딩 규칙을 유지합니다.
+        </p>
+      </Card>
+    </Container>
+  ),
+};

--- a/packages/gocheok-project/src/components/layout/container/Container.tsx
+++ b/packages/gocheok-project/src/components/layout/container/Container.tsx
@@ -1,0 +1,49 @@
+import type { HTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const maxWidthClassNames = {
+  sm: 'max-w-2xl',
+  md: 'max-w-4xl',
+  lg: 'max-w-6xl',
+  xl: 'max-w-7xl',
+  full: 'max-w-none',
+} as const;
+
+const paddingClassNames = {
+  none: 'px-0',
+  sm: 'px-4',
+  md: 'px-6',
+  lg: 'px-8',
+  xl: 'px-10',
+} as const;
+
+export type ContainerSize = keyof typeof maxWidthClassNames;
+export type ContainerPadding = keyof typeof paddingClassNames;
+
+export interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
+  size?: ContainerSize;
+  padding?: ContainerPadding;
+  centered?: boolean;
+}
+
+export function Container({
+  className,
+  size = 'lg',
+  padding = 'md',
+  centered = true,
+  ...props
+}: ContainerProps) {
+  return (
+    <div
+      className={twMerge(
+        'w-full',
+        maxWidthClassNames[size],
+        paddingClassNames[padding],
+        centered && 'mx-auto',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/container/index.ts
+++ b/packages/gocheok-project/src/components/layout/container/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/layout/container/Container';

--- a/packages/gocheok-project/src/components/layout/flex/Flex.stories.tsx
+++ b/packages/gocheok-project/src/components/layout/flex/Flex.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Badge } from '@gocheok/components/presenter/badge/Badge';
+import { Flex } from '@gocheok/components/layout/flex/Flex';
+
+const meta: Meta<typeof Flex> = {
+  title: 'Layout/Flex/Default',
+  component: Flex,
+  decorators: [
+    (Story) => (
+      <div className="max-w-3xl p-6 text-(--color-foreground)">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Flex>;
+
+export const Default: Story = {
+  render: () => (
+    <Flex justify="between" className="rounded-2xl border border-(--color-border) p-5">
+      <div>
+        <strong className="block text-sm">예매 현황</strong>
+        <p className="mt-1 text-sm text-(--color-grey-600)">좌석 선택이 3건 남았습니다.</p>
+      </div>
+      <Badge variant="primary">진행 중</Badge>
+    </Flex>
+  ),
+};
+
+export const Wrapped: Story = {
+  render: () => (
+    <Flex gap="sm" wrap>
+      <Badge>주말</Badge>
+      <Badge variant="success">공연 확정</Badge>
+      <Badge variant="warning">대기</Badge>
+      <Badge variant="danger">마감 임박</Badge>
+    </Flex>
+  ),
+};

--- a/packages/gocheok-project/src/components/layout/flex/Flex.tsx
+++ b/packages/gocheok-project/src/components/layout/flex/Flex.tsx
@@ -1,0 +1,71 @@
+import type { HTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const directionClassNames = {
+  row: 'flex-row',
+  column: 'flex-col',
+} as const;
+
+const gapClassNames = {
+  none: 'gap-0',
+  xs: 'gap-2',
+  sm: 'gap-3',
+  md: 'gap-4',
+  lg: 'gap-6',
+  xl: 'gap-8',
+} as const;
+
+const alignClassNames = {
+  stretch: 'items-stretch',
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  baseline: 'items-baseline',
+} as const;
+
+const justifyClassNames = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+  between: 'justify-between',
+  around: 'justify-around',
+} as const;
+
+export type FlexDirection = keyof typeof directionClassNames;
+export type FlexGap = keyof typeof gapClassNames;
+export type FlexAlign = keyof typeof alignClassNames;
+export type FlexJustify = keyof typeof justifyClassNames;
+
+export interface FlexProps extends HTMLAttributes<HTMLDivElement> {
+  direction?: FlexDirection;
+  gap?: FlexGap;
+  align?: FlexAlign;
+  justify?: FlexJustify;
+  wrap?: boolean;
+}
+
+export function Flex({
+  className,
+  direction = 'row',
+  gap = 'md',
+  align = 'center',
+  justify = 'start',
+  wrap = false,
+  ...props
+}: FlexProps) {
+  return (
+    <div
+      className={twMerge(
+        'flex',
+        directionClassNames[direction],
+        gapClassNames[gap],
+        alignClassNames[align],
+        justifyClassNames[justify],
+        wrap && 'flex-wrap',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/flex/index.ts
+++ b/packages/gocheok-project/src/components/layout/flex/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/layout/flex/Flex';

--- a/packages/gocheok-project/src/components/layout/grid/Grid.stories.tsx
+++ b/packages/gocheok-project/src/components/layout/grid/Grid.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Card } from '@gocheok/components/presenter/card/Card';
+import { Grid } from '@gocheok/components/layout/grid/Grid';
+
+const meta: Meta<typeof Grid> = {
+  title: 'Layout/Grid/Default',
+  component: Grid,
+  decorators: [
+    (Story) => (
+      <div className="max-w-5xl p-6 text-(--color-foreground)">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Grid>;
+
+export const Default: Story = {
+  render: () => (
+    <Grid columns={3}>
+      <Card padding="md">공연</Card>
+      <Card padding="md">예매</Card>
+      <Card padding="md">정산</Card>
+    </Grid>
+  ),
+};
+
+export const TwoColumns: Story = {
+  render: () => (
+    <Grid columns={2} gap="lg">
+      <Card>
+        <strong className="text-base">A 구역</strong>
+        <p className="mt-2 text-sm text-(--color-grey-600)">잔여 좌석 12석</p>
+      </Card>
+      <Card tone="muted">
+        <strong className="text-base">B 구역</strong>
+        <p className="mt-2 text-sm text-(--color-grey-600)">잔여 좌석 8석</p>
+      </Card>
+    </Grid>
+  ),
+};

--- a/packages/gocheok-project/src/components/layout/grid/Grid.tsx
+++ b/packages/gocheok-project/src/components/layout/grid/Grid.tsx
@@ -1,0 +1,36 @@
+import type { HTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const columnsClassNames = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4',
+} as const;
+
+const gapClassNames = {
+  none: 'gap-0',
+  xs: 'gap-2',
+  sm: 'gap-3',
+  md: 'gap-4',
+  lg: 'gap-6',
+  xl: 'gap-8',
+} as const;
+
+export type GridColumns = keyof typeof columnsClassNames;
+export type GridGap = keyof typeof gapClassNames;
+
+export interface GridProps extends HTMLAttributes<HTMLDivElement> {
+  columns?: GridColumns;
+  gap?: GridGap;
+}
+
+export function Grid({ className, columns = 3, gap = 'md', ...props }: GridProps) {
+  return (
+    <div
+      className={twMerge('grid', columnsClassNames[columns], gapClassNames[gap], className)}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/grid/index.ts
+++ b/packages/gocheok-project/src/components/layout/grid/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/layout/grid/Grid';

--- a/packages/gocheok-project/src/components/layout/stack/Stack.stories.tsx
+++ b/packages/gocheok-project/src/components/layout/stack/Stack.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Card } from '@gocheok/components/presenter/card/Card';
+import { Stack } from '@gocheok/components/layout/stack/Stack';
+
+const meta: Meta<typeof Stack> = {
+  title: 'Layout/Stack/Default',
+  component: Stack,
+  decorators: [
+    (Story) => (
+      <div className="max-w-md p-6 text-(--color-foreground)">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Stack>;
+
+export const Default: Story = {
+  render: () => (
+    <Stack>
+      <Card padding="md">첫 번째 블록</Card>
+      <Card padding="md">두 번째 블록</Card>
+      <Card padding="md">세 번째 블록</Card>
+    </Stack>
+  ),
+};
+
+export const Centered: Story = {
+  render: () => (
+    <Stack align="center" gap="lg">
+      <Card className="w-full max-w-xs" padding="md">
+        중앙 정렬
+      </Card>
+      <Card className="w-full max-w-xs" padding="md" tone="muted">
+        간격 토큰
+      </Card>
+    </Stack>
+  ),
+};

--- a/packages/gocheok-project/src/components/layout/stack/Stack.tsx
+++ b/packages/gocheok-project/src/components/layout/stack/Stack.tsx
@@ -1,0 +1,57 @@
+import type { HTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const gapClassNames = {
+  none: 'gap-0',
+  xs: 'gap-2',
+  sm: 'gap-3',
+  md: 'gap-4',
+  lg: 'gap-6',
+  xl: 'gap-8',
+} as const;
+
+const alignClassNames = {
+  stretch: 'items-stretch',
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+} as const;
+
+const justifyClassNames = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+  between: 'justify-between',
+} as const;
+
+export type StackGap = keyof typeof gapClassNames;
+export type StackAlign = keyof typeof alignClassNames;
+export type StackJustify = keyof typeof justifyClassNames;
+
+export interface StackProps extends HTMLAttributes<HTMLDivElement> {
+  gap?: StackGap;
+  align?: StackAlign;
+  justify?: StackJustify;
+}
+
+export function Stack({
+  className,
+  gap = 'md',
+  align = 'stretch',
+  justify = 'start',
+  ...props
+}: StackProps) {
+  return (
+    <div
+      className={twMerge(
+        'flex flex-col',
+        gapClassNames[gap],
+        alignClassNames[align],
+        justifyClassNames[justify],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/layout/stack/index.ts
+++ b/packages/gocheok-project/src/components/layout/stack/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/layout/stack/Stack';

--- a/packages/gocheok-project/src/components/presenter/avatar/Avatar.stories.tsx
+++ b/packages/gocheok-project/src/components/presenter/avatar/Avatar.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Avatar } from '@gocheok/components/presenter/avatar/Avatar';
+import { Flex } from '@gocheok/components/layout/flex/Flex';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Presenter/Avatar/Default',
+  component: Avatar,
+  decorators: [
+    (Story) => (
+      <div className="p-6 text-(--color-foreground)">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Fallback: Story = {
+  render: () => (
+    <Flex gap="md">
+      <Avatar name="Min Byeongchan" />
+      <Avatar name="MBC Story" size="lg" />
+      <Avatar name="Guest" size="xl" shape="square" />
+    </Flex>
+  ),
+};
+
+export const WithImage: Story = {
+  args: {
+    name: 'Storybook',
+    alt: 'Storybook avatar',
+    src: 'https://placehold.co/160x160/e8f3ff/2272eb?text=SB',
+    size: 'xl',
+  },
+};

--- a/packages/gocheok-project/src/components/presenter/avatar/Avatar.tsx
+++ b/packages/gocheok-project/src/components/presenter/avatar/Avatar.tsx
@@ -1,0 +1,67 @@
+import type { HTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const sizeClassNames = {
+  sm: 'h-8 w-8 text-xs',
+  md: 'h-10 w-10 text-sm',
+  lg: 'h-14 w-14 text-base',
+  xl: 'h-20 w-20 text-xl',
+} as const;
+
+const shapeClassNames = {
+  circle: 'rounded-full',
+  square: 'rounded-2xl',
+} as const;
+
+export type AvatarSize = keyof typeof sizeClassNames;
+export type AvatarShape = keyof typeof shapeClassNames;
+
+export interface AvatarProps extends HTMLAttributes<HTMLDivElement> {
+  src?: string;
+  alt?: string;
+  name?: string;
+  size?: AvatarSize;
+  shape?: AvatarShape;
+}
+
+function getInitials(name?: string) {
+  if (!name) return '?';
+
+  const words = name.trim().split(/\s+/).filter(Boolean).slice(0, 2);
+
+  if (words.length === 0) return '?';
+
+  return words.map((word) => word[0]?.toUpperCase() ?? '').join('');
+}
+
+export function Avatar({
+  className,
+  src,
+  alt,
+  name,
+  size = 'md',
+  shape = 'circle',
+  ...props
+}: AvatarProps) {
+  const fallbackLabel = getInitials(name);
+
+  return (
+    <div
+      className={twMerge(
+        'inline-flex shrink-0 items-center justify-center overflow-hidden border border-(--color-border) bg-(--color-grey-100) font-semibold text-(--color-grey-700)',
+        sizeClassNames[size],
+        shapeClassNames[shape],
+        className,
+      )}
+      aria-label={alt ?? name ?? 'avatar'}
+      {...props}
+    >
+      {src ? (
+        <img src={src} alt={alt ?? name ?? 'avatar'} className="h-full w-full object-cover" />
+      ) : (
+        <span aria-hidden>{fallbackLabel}</span>
+      )}
+    </div>
+  );
+}

--- a/packages/gocheok-project/src/components/presenter/avatar/index.ts
+++ b/packages/gocheok-project/src/components/presenter/avatar/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/presenter/avatar/Avatar';

--- a/packages/gocheok-project/src/components/presenter/badge/Badge.stories.tsx
+++ b/packages/gocheok-project/src/components/presenter/badge/Badge.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Badge } from '@gocheok/components/presenter/badge/Badge';
+import { Flex } from '@gocheok/components/layout/flex/Flex';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Presenter/Badge/Default',
+  component: Badge,
+  decorators: [
+    (Story) => (
+      <div className="p-6 text-(--color-foreground)">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Variants: Story = {
+  render: () => (
+    <Flex gap="sm" wrap>
+      <Badge>기본</Badge>
+      <Badge variant="primary">정보</Badge>
+      <Badge variant="success">정상</Badge>
+      <Badge variant="warning">대기</Badge>
+      <Badge variant="danger">오류</Badge>
+    </Flex>
+  ),
+};
+
+export const Small: Story = {
+  args: {
+    children: 'SMALL',
+    size: 'sm',
+    variant: 'primary',
+  },
+};

--- a/packages/gocheok-project/src/components/presenter/badge/Badge.tsx
+++ b/packages/gocheok-project/src/components/presenter/badge/Badge.tsx
@@ -1,0 +1,46 @@
+import type { HTMLAttributes, PropsWithChildren } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const variantClassNames = {
+  neutral: 'border-(--color-border) bg-(--color-grey-100) text-(--color-grey-800)',
+  primary: 'border-(--color-blue-100) bg-(--color-blue-50) text-(--color-blue-700)',
+  success: 'border-(--color-green-100) bg-(--color-green-50) text-(--color-green-700)',
+  warning: 'border-(--color-orange-100) bg-(--color-orange-50) text-(--color-orange-700)',
+  danger: 'border-(--color-red-100) bg-(--color-red-50) text-(--color-red-700)',
+} as const;
+
+const sizeClassNames = {
+  sm: 'px-2 py-0.5 text-xs',
+  md: 'px-2.5 py-1 text-xs',
+} as const;
+
+export type BadgeVariant = keyof typeof variantClassNames;
+export type BadgeSize = keyof typeof sizeClassNames;
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement>, PropsWithChildren {
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+}
+
+export function Badge({
+  children,
+  className,
+  variant = 'neutral',
+  size = 'md',
+  ...props
+}: BadgeProps) {
+  return (
+    <span
+      className={twMerge(
+        'inline-flex items-center rounded-full border font-medium whitespace-nowrap',
+        variantClassNames[variant],
+        sizeClassNames[size],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/gocheok-project/src/components/presenter/badge/index.ts
+++ b/packages/gocheok-project/src/components/presenter/badge/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/presenter/badge/Badge';

--- a/packages/gocheok-project/src/components/presenter/card/Card.stories.tsx
+++ b/packages/gocheok-project/src/components/presenter/card/Card.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Badge } from '@gocheok/components/presenter/badge/Badge';
+import { Card } from '@gocheok/components/presenter/card/Card';
+import { Flex } from '@gocheok/components/layout/flex/Flex';
+import { Stack } from '@gocheok/components/layout/stack/Stack';
+
+const meta: Meta<typeof Card> = {
+  title: 'Presenter/Card/Default',
+  component: Card,
+  decorators: [
+    (Story) => (
+      <div className="max-w-lg p-6 text-(--color-foreground)">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  render: () => (
+    <Card>
+      <Stack gap="sm">
+        <Flex justify="between">
+          <strong className="text-lg">프로필 요약</strong>
+          <Badge variant="primary">활성</Badge>
+        </Flex>
+        <p className="text-sm text-(--color-grey-600)">
+          카드 컴포넌트는 요약 블록, 리스트 아이템, 프로필 패널에 공통으로 사용할 수 있습니다.
+        </p>
+      </Stack>
+    </Card>
+  ),
+};
+
+export const Inverse: Story = {
+  render: () => (
+    <Card tone="inverse">
+      <Stack gap="xs">
+        <strong className="text-lg">다크 섹션</strong>
+        <p className="text-sm text-(--color-neutral-200)">
+          강조 영역이나 히어로 블록에 사용할 수 있습니다.
+        </p>
+      </Stack>
+    </Card>
+  ),
+};

--- a/packages/gocheok-project/src/components/presenter/card/Card.tsx
+++ b/packages/gocheok-project/src/components/presenter/card/Card.tsx
@@ -1,0 +1,39 @@
+import type { HTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const paddingClassNames = {
+  none: 'p-0',
+  sm: 'p-4',
+  md: 'p-5',
+  lg: 'p-6',
+  xl: 'p-8',
+} as const;
+
+const toneClassNames = {
+  default: 'border-(--color-border) bg-(--color-card) text-(--color-card-foreground)',
+  muted: 'border-(--color-border) bg-(--color-grey-50) text-(--color-foreground)',
+  inverse: 'border-(--color-bg-300) bg-(--color-bg-100) text-(--color-neutral-100)',
+} as const;
+
+export type CardPadding = keyof typeof paddingClassNames;
+export type CardTone = keyof typeof toneClassNames;
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  padding?: CardPadding;
+  tone?: CardTone;
+}
+
+export function Card({ className, padding = 'lg', tone = 'default', ...props }: CardProps) {
+  return (
+    <article
+      className={twMerge(
+        'rounded-2xl border shadow-sm',
+        paddingClassNames[padding],
+        toneClassNames[tone],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/presenter/card/index.ts
+++ b/packages/gocheok-project/src/components/presenter/card/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/presenter/card/Card';


### PR DESCRIPTION
## Summary
- `gocheok-project`에 `Container`, `Stack`, `Flex`, `Grid` 레이아웃 프리미티브를 추가했습니다.
- `Card`, `Badge`, `Avatar` 데이터 표시 컴포넌트와 각 Storybook 스토리를 추가했습니다.
- 패키지 루트 export를 갱신해 새 컴포넌트를 공용 진입점에서 사용할 수 있게 했습니다.

## Test plan
- [x] `pnpm lint:gocheok`
- [x] `pnpm build:gocheok`

Fixes #39

Made with [Cursor](https://cursor.com)