### PR TITLE
feat(gocheok-project): 커스텀 오버레이 프리미티브 추가

### DIFF
--- a/.cursor/rules/korean-response.mdc
+++ b/.cursor/rules/korean-response.mdc
@@ -1,0 +1,11 @@
+---
+description: Always respond to the user in Korean
+alwaysApply: true
+---
+
+# Korean Response Rule
+
+- 사용자에게 보내는 응답은 항상 한글로 작성한다.
+- 코드, 명령어, 파일 경로, 식별자는 필요할 때만 원문 그대로 유지한다.
+- PR 제목, 커밋 메시지, 설명문을 작성할 때도 사용자가 별도 요청하지 않으면 한글을 우선한다.
+- 영어 자료를 참고하더라도 사용자에게 전달하는 최종 설명은 한글로 정리한다.

--- a/packages/gocheok-project/package.json
+++ b/packages/gocheok-project/package.json
@@ -13,12 +13,10 @@
   },
   "peerDependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@radix-ui/react-dialog": "^1.1.15"
+    "react-dom": "^19.0.0"
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
-    "@radix-ui/react-dialog": "^1.1.15",
     "@tailwindcss/vite": "catalog:tailwindcss",
     "gsap": "^3.13.0",
     "react": "catalog:react",

--- a/packages/gocheok-project/src/components/feedback/popover/Popover.stories.tsx
+++ b/packages/gocheok-project/src/components/feedback/popover/Popover.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '@gocheok/components/actions/button/Button';
+import { Popover, PopoverContent, PopoverTrigger } from '@gocheok/components/feedback/popover';
+
+const meta: Meta<typeof Popover> = {
+  title: 'Feedback/Popover/Default',
+  component: Popover,
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-80 items-center justify-center p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button className="rounded-lg border border-(--color-border) bg-white px-4 py-2 text-sm text-(--color-foreground)">
+          빠른 정보
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="space-y-3">
+        <div>
+          <p className="text-sm font-semibold text-(--color-foreground)">오늘의 발행 현황</p>
+          <p className="mt-1 text-sm text-(--color-muted-foreground)">
+            예약 발행 3건, 검수 대기 1건
+          </p>
+        </div>
+        <div className="rounded-xl bg-(--color-muted) p-3 text-sm text-(--color-foreground)">
+          오후 6시 전에 검수를 완료하면 오늘 안에 노출됩니다.
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+};

--- a/packages/gocheok-project/src/components/feedback/popover/Popover.tsx
+++ b/packages/gocheok-project/src/components/feedback/popover/Popover.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import React, {
+  useCallback,
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { twMerge } from 'tailwind-merge';
+
+type PopoverAlign = 'start' | 'center' | 'end';
+
+type PopoverContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  triggerRef: React.MutableRefObject<HTMLElement | null>;
+  anchorRef: React.MutableRefObject<HTMLElement | null>;
+  contentRef: React.MutableRefObject<HTMLDivElement | null>;
+};
+
+const PopoverContext = createContext<PopoverContextValue | null>(null);
+
+const usePopoverContext = () => {
+  const context = useContext(PopoverContext);
+
+  if (context == null) {
+    throw new Error('Popover 컴포넌트 내부에서만 사용할 수 있습니다.');
+  }
+
+  return context;
+};
+
+type PopoverProps = React.PropsWithChildren<{
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}>;
+
+export const Popover = ({
+  children,
+  defaultOpen = false,
+  open: controlledOpen,
+  onOpenChange,
+}: PopoverProps) => {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const anchorRef = useRef<HTMLElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const open = controlledOpen ?? uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (controlledOpen == null) {
+        setUncontrolledOpen(nextOpen);
+      }
+
+      onOpenChange?.(nextOpen);
+    },
+    [controlledOpen, onOpenChange],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      const anchorElement = anchorRef.current ?? triggerRef.current;
+
+      if (contentRef.current?.contains(target) || anchorElement?.contains(target)) {
+        return;
+      }
+
+      setOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, setOpen]);
+
+  const contextValue = {
+    open,
+    setOpen,
+    triggerRef,
+    anchorRef,
+    contentRef,
+  };
+
+  return <PopoverContext.Provider value={contextValue}>{children}</PopoverContext.Provider>;
+};
+
+type PopoverTriggerProps = React.HTMLAttributes<HTMLElement> & {
+  asChild?: boolean;
+};
+
+export const PopoverTrigger = ({
+  asChild = false,
+  children,
+  className,
+  onClick,
+  ...props
+}: PopoverTriggerProps) => {
+  const { open, setOpen, triggerRef } = usePopoverContext();
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+
+    setOpen(!open);
+  };
+
+  if (asChild) {
+    return (
+      <span
+        ref={(node) => {
+          triggerRef.current = node;
+        }}
+        className={twMerge('inline-flex', className)}
+        onClick={handleClick}
+        {...props}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      ref={(node) => {
+        triggerRef.current = node;
+      }}
+      type="button"
+      className={className}
+      onClick={handleClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+type PopoverAnchorProps = React.HTMLAttributes<HTMLElement> & {
+  asChild?: boolean;
+};
+
+export const PopoverAnchor = ({
+  asChild = false,
+  children,
+  className,
+  ...props
+}: PopoverAnchorProps) => {
+  const { anchorRef } = usePopoverContext();
+
+  if (asChild) {
+    return (
+      <span
+        ref={(node) => {
+          anchorRef.current = node;
+        }}
+        className={twMerge('inline-flex', className)}
+        {...props}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      ref={(node) => {
+        anchorRef.current = node;
+      }}
+      className={className}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+};
+
+type PopoverContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  align?: PopoverAlign;
+  sideOffset?: number;
+};
+
+export const PopoverContent = ({
+  className,
+  align = 'center',
+  sideOffset = 8,
+  ...props
+}: PopoverContentProps) => {
+  const { open, triggerRef, anchorRef, contentRef } = usePopoverContext();
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || contentRef.current == null) {
+      return;
+    }
+
+    const anchorElement = anchorRef.current ?? triggerRef.current;
+    if (anchorElement == null) {
+      return;
+    }
+
+    const anchorRect = anchorElement.getBoundingClientRect();
+    const contentRect = contentRef.current.getBoundingClientRect();
+
+    let left = anchorRect.left;
+
+    if (align === 'center') {
+      left = anchorRect.left + anchorRect.width / 2 - contentRect.width / 2;
+    }
+
+    if (align === 'end') {
+      left = anchorRect.right - contentRect.width;
+    }
+
+    setPosition({
+      top: Math.min(anchorRect.bottom + sideOffset, window.innerHeight - contentRect.height - 8),
+      left: Math.min(Math.max(8, left), window.innerWidth - contentRect.width - 8),
+    });
+  }, [align, open, sideOffset, anchorRef, contentRef, triggerRef]);
+
+  if (!open || typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      ref={(node) => {
+        contentRef.current = node;
+      }}
+      data-state="open"
+      className={twMerge(
+        'fixed z-201 w-80 rounded-2xl border border-(--color-border) bg-(--color-popover) p-4 text-(--color-popover-foreground) shadow-xl',
+        'data-[state=closed]:animate-surface-out data-[state=open]:animate-surface-in',
+        className,
+      )}
+      style={
+        position == null ? { visibility: 'hidden' } : { top: position.top, left: position.left }
+      }
+      {...props}
+    />,
+    document.body,
+  );
+};

--- a/packages/gocheok-project/src/components/feedback/popover/index.ts
+++ b/packages/gocheok-project/src/components/feedback/popover/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/feedback/popover/Popover';

--- a/packages/gocheok-project/src/components/feedback/tooltip/Tooltip.stories.tsx
+++ b/packages/gocheok-project/src/components/feedback/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '@gocheok/components/actions/button/Button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@gocheok/components/feedback/tooltip';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Feedback/Tooltip/Default',
+  component: Tooltip,
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-48 items-center justify-center p-6">
+        <TooltipProvider delayDuration={120}>
+          <Story />
+        </TooltipProvider>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button className="rounded-lg border border-(--color-border) bg-white px-4 py-2 text-sm text-(--color-foreground)">
+          도움말 보기
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>게시글 상태를 한눈에 확인할 수 있어요.</TooltipContent>
+    </Tooltip>
+  ),
+};

--- a/packages/gocheok-project/src/components/feedback/tooltip/Tooltip.tsx
+++ b/packages/gocheok-project/src/components/feedback/tooltip/Tooltip.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import React, {
+  useCallback,
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { twMerge } from 'tailwind-merge';
+
+type TooltipProviderContextValue = {
+  delayDuration: number;
+};
+
+type TooltipContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  triggerRef: React.MutableRefObject<HTMLElement | null>;
+};
+
+const TooltipProviderContext = createContext<TooltipProviderContextValue>({
+  delayDuration: 700,
+});
+const TooltipContext = createContext<TooltipContextValue | null>(null);
+
+const useTooltipContext = () => {
+  const context = useContext(TooltipContext);
+
+  if (context == null) {
+    throw new Error('Tooltip 컴포넌트 내부에서만 사용할 수 있습니다.');
+  }
+
+  return context;
+};
+
+type TooltipProviderProps = React.PropsWithChildren<{
+  delayDuration?: number;
+}>;
+
+export const TooltipProvider = ({ children, delayDuration = 700 }: TooltipProviderProps) => {
+  const value = useMemo(() => ({ delayDuration }), [delayDuration]);
+
+  return (
+    <TooltipProviderContext.Provider value={value}>{children}</TooltipProviderContext.Provider>
+  );
+};
+
+type TooltipProps = React.PropsWithChildren<{
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}>;
+
+export const Tooltip = ({
+  children,
+  defaultOpen = false,
+  open: controlledOpen,
+  onOpenChange,
+}: TooltipProps) => {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const open = controlledOpen ?? uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (controlledOpen == null) {
+        setUncontrolledOpen(nextOpen);
+      }
+
+      onOpenChange?.(nextOpen);
+    },
+    [controlledOpen, onOpenChange],
+  );
+
+  const contextValue = {
+    open,
+    setOpen,
+    triggerRef,
+  };
+
+  return <TooltipContext.Provider value={contextValue}>{children}</TooltipContext.Provider>;
+};
+
+type TooltipTriggerProps = React.HTMLAttributes<HTMLElement> & {
+  asChild?: boolean;
+};
+
+export const TooltipTrigger = ({
+  asChild = false,
+  children,
+  className,
+  onFocus,
+  onBlur,
+  onMouseEnter,
+  onMouseLeave,
+  ...props
+}: TooltipTriggerProps) => {
+  const { delayDuration } = useContext(TooltipProviderContext);
+  const { open, setOpen, triggerRef } = useTooltipContext();
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = () => {
+    if (timerRef.current == null) return;
+
+    window.clearTimeout(timerRef.current);
+    timerRef.current = null;
+  };
+
+  const openWithDelay = () => {
+    clearTimer();
+    timerRef.current = window.setTimeout(() => {
+      setOpen(true);
+    }, delayDuration);
+  };
+
+  const closeTooltip = () => {
+    clearTimer();
+    setOpen(false);
+  };
+
+  useEffect(() => clearTimer, []);
+
+  const sharedProps = {
+    className: asChild ? twMerge('inline-flex', className) : className,
+    onMouseEnter: (event: React.MouseEvent<HTMLElement>) => {
+      onMouseEnter?.(event);
+      if (!event.defaultPrevented) {
+        openWithDelay();
+      }
+    },
+    onMouseLeave: (event: React.MouseEvent<HTMLElement>) => {
+      onMouseLeave?.(event);
+      if (!event.defaultPrevented) {
+        closeTooltip();
+      }
+    },
+    onFocus: (event: React.FocusEvent<HTMLElement>) => {
+      onFocus?.(event);
+      if (!event.defaultPrevented) {
+        openWithDelay();
+      }
+    },
+    onBlur: (event: React.FocusEvent<HTMLElement>) => {
+      onBlur?.(event);
+      if (!event.defaultPrevented) {
+        closeTooltip();
+      }
+    },
+    'aria-describedby': open ? 'tooltip-content' : undefined,
+    ...props,
+  };
+
+  if (asChild) {
+    return (
+      <span
+        ref={(node) => {
+          triggerRef.current = node;
+        }}
+        {...sharedProps}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      ref={(node) => {
+        triggerRef.current = node;
+      }}
+      type="button"
+      {...sharedProps}
+    >
+      {children}
+    </button>
+  );
+};
+
+type TooltipContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  sideOffset?: number;
+};
+
+export const TooltipContent = ({ className, sideOffset = 8, ...props }: TooltipContentProps) => {
+  const { open, triggerRef } = useTooltipContext();
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || triggerRef.current == null || contentRef.current == null) {
+      return;
+    }
+
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const contentRect = contentRef.current.getBoundingClientRect();
+
+    const left = triggerRect.left + triggerRect.width / 2 - contentRect.width / 2;
+    const top = triggerRect.top - contentRect.height - sideOffset;
+
+    setPosition({
+      top: Math.max(8, top),
+      left: Math.min(Math.max(8, left), window.innerWidth - contentRect.width - 8),
+    });
+  }, [open, sideOffset, triggerRef]);
+
+  if (!open || typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      id="tooltip-content"
+      ref={contentRef}
+      role="tooltip"
+      data-state="open"
+      className={twMerge(
+        'fixed z-201 rounded-md bg-(--color-grey-900) px-3 py-2 text-xs text-white shadow-lg',
+        'data-[state=closed]:animate-surface-out data-[state=open]:animate-surface-in',
+        className,
+      )}
+      style={
+        position == null ? { visibility: 'hidden' } : { top: position.top, left: position.left }
+      }
+      {...props}
+    />,
+    document.body,
+  );
+};

--- a/packages/gocheok-project/src/components/feedback/tooltip/index.ts
+++ b/packages/gocheok-project/src/components/feedback/tooltip/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/feedback/tooltip/Tooltip';

--- a/packages/gocheok-project/src/components/forms/select/SelectDialog.tsx
+++ b/packages/gocheok-project/src/components/forms/select/SelectDialog.tsx
@@ -1,4 +1,7 @@
-import * as Dialog from '@radix-ui/react-dialog';
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { twMerge } from 'tailwind-merge';
 
 import { useSelectContext } from '@gocheok/components/forms/select/SelectContext';
@@ -9,39 +12,81 @@ type SelectDialogProps = {
 
 export const SelectDialog = ({ children }: SelectDialogProps) => {
   const { state, dispatch } = useSelectContext();
-  const isMobile = window.innerWidth < 768;
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [isMobile, setIsMobile] = useState(false);
   const position = state.dialogPosition;
 
-  const handleOpenChange = (open: boolean) => {
-    dispatch({ type: 'SET_OPEN', open });
-  };
+  useEffect(() => {
+    const updateViewport = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
 
-  return (
-    <Dialog.Root open={state.isOpen} onOpenChange={handleOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay
-          data-state={state.isOpen ? 'open' : 'closed'}
-          className={twMerge(
-            'pointer-events-none fixed inset-0 z-200',
-            'data-[state=closed]:animate-overlay-hide data-[state=open]:animate-overlay-show',
-            isMobile && 'pointer-events-auto bg-black/50',
-          )}
-        />
-        <Dialog.Content
-          className={twMerge(
-            'max-w-440px fixed z-201 transform overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none',
-            'data-[state=closed]:animate-select-dialog-out data-[state=open]:animate-select-dialog-in',
-            isMobile && 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
-          )}
-          style={
-            !isMobile && position
-              ? { top: position.y, left: position.x, transform: 'none' }
-              : undefined
-          }
-        >
-          {children}
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    updateViewport();
+    window.addEventListener('resize', updateViewport);
+
+    return () => window.removeEventListener('resize', updateViewport);
+  }, []);
+
+  useEffect(() => {
+    if (!state.isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        dispatch({ type: 'SET_OPEN', open: false });
+      }
+    };
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (contentRef.current?.contains(target)) {
+        return;
+      }
+
+      dispatch({ type: 'SET_OPEN', open: false });
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('mousedown', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handlePointerDown);
+    };
+  }, [dispatch, state.isOpen]);
+
+  if (!state.isOpen || typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
+    <>
+      <div
+        data-state="open"
+        className={twMerge(
+          'pointer-events-none fixed inset-0 z-200',
+          'data-[state=closed]:animate-overlay-hide data-[state=open]:animate-overlay-show',
+          isMobile && 'pointer-events-auto bg-black/50',
+        )}
+      />
+      <div
+        ref={contentRef}
+        className={twMerge(
+          'max-w-440px fixed z-201 transform overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none',
+          'data-[state=closed]:animate-select-dialog-out data-[state=open]:animate-select-dialog-in',
+          isMobile && 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
+        )}
+        data-state="open"
+        style={
+          !isMobile && position
+            ? { top: position.y, left: position.x, transform: 'none' }
+            : undefined
+        }
+      >
+        {children}
+      </div>
+    </>,
+    document.body,
   );
 };

--- a/packages/gocheok-project/src/components/navigation/menu/Menu.stories.tsx
+++ b/packages/gocheok-project/src/components/navigation/menu/Menu.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '@gocheok/components/actions/button/Button';
+import {
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuLabel,
+  MenuSeparator,
+  MenuTrigger,
+} from '@gocheok/components/navigation/menu';
+
+const meta: Meta<typeof Menu> = {
+  title: 'Navigation/Menu/Default',
+  component: Menu,
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-80 items-center justify-center p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Menu>;
+
+export const Default: Story = {
+  render: () => (
+    <Menu>
+      <MenuTrigger asChild>
+        <Button className="rounded-lg border border-(--color-border) bg-white px-4 py-2 text-sm text-(--color-foreground)">
+          더보기
+        </Button>
+      </MenuTrigger>
+      <MenuContent>
+        <MenuLabel>게시글 액션</MenuLabel>
+        <MenuItem>수정하기</MenuItem>
+        <MenuItem>미리보기</MenuItem>
+        <MenuSeparator />
+        <MenuItem className="text-(--color-red-600)">삭제하기</MenuItem>
+      </MenuContent>
+    </Menu>
+  ),
+};

--- a/packages/gocheok-project/src/components/navigation/menu/Menu.tsx
+++ b/packages/gocheok-project/src/components/navigation/menu/Menu.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import React, {
+  useCallback,
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { twMerge } from 'tailwind-merge';
+
+type MenuAlign = 'start' | 'center' | 'end';
+
+type MenuContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  triggerRef: React.MutableRefObject<HTMLElement | null>;
+  contentRef: React.MutableRefObject<HTMLDivElement | null>;
+};
+
+const MenuContext = createContext<MenuContextValue | null>(null);
+
+const useMenuContext = () => {
+  const context = useContext(MenuContext);
+
+  if (context == null) {
+    throw new Error('Menu 컴포넌트 내부에서만 사용할 수 있습니다.');
+  }
+
+  return context;
+};
+
+type MenuProps = React.PropsWithChildren<{
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}>;
+
+export const Menu = ({
+  children,
+  defaultOpen = false,
+  open: controlledOpen,
+  onOpenChange,
+}: MenuProps) => {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const open = controlledOpen ?? uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (controlledOpen == null) {
+        setUncontrolledOpen(nextOpen);
+      }
+
+      onOpenChange?.(nextOpen);
+    },
+    [controlledOpen, onOpenChange],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (contentRef.current?.contains(target) || triggerRef.current?.contains(target)) {
+        return;
+      }
+
+      setOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, setOpen]);
+
+  const contextValue = {
+    open,
+    setOpen,
+    triggerRef,
+    contentRef,
+  };
+
+  return <MenuContext.Provider value={contextValue}>{children}</MenuContext.Provider>;
+};
+
+type MenuTriggerProps = React.HTMLAttributes<HTMLElement> & {
+  asChild?: boolean;
+};
+
+export const MenuTrigger = ({
+  asChild = false,
+  children,
+  className,
+  onClick,
+  ...props
+}: MenuTriggerProps) => {
+  const { open, setOpen, triggerRef } = useMenuContext();
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+
+    setOpen(!open);
+  };
+
+  if (asChild) {
+    return (
+      <span
+        ref={(node) => {
+          triggerRef.current = node;
+        }}
+        className={twMerge('inline-flex', className)}
+        onClick={handleClick}
+        {...props}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      ref={(node) => {
+        triggerRef.current = node;
+      }}
+      type="button"
+      className={className}
+      onClick={handleClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+type MenuContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  align?: MenuAlign;
+  sideOffset?: number;
+};
+
+export const MenuContent = ({
+  className,
+  align = 'end',
+  sideOffset = 8,
+  ...props
+}: MenuContentProps) => {
+  const { open, triggerRef, contentRef } = useMenuContext();
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || triggerRef.current == null || contentRef.current == null) {
+      return;
+    }
+
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const contentRect = contentRef.current.getBoundingClientRect();
+
+    let left = triggerRect.left;
+
+    if (align === 'center') {
+      left = triggerRect.left + triggerRect.width / 2 - contentRect.width / 2;
+    }
+
+    if (align === 'end') {
+      left = triggerRect.right - contentRect.width;
+    }
+
+    setPosition({
+      top: Math.min(triggerRect.bottom + sideOffset, window.innerHeight - contentRect.height - 8),
+      left: Math.min(Math.max(8, left), window.innerWidth - contentRect.width - 8),
+    });
+  }, [align, open, sideOffset, contentRef, triggerRef]);
+
+  if (!open || typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      ref={(node) => {
+        contentRef.current = node;
+      }}
+      role="menu"
+      data-state="open"
+      className={twMerge(
+        'fixed z-201 min-w-48 rounded-2xl border border-(--color-border) bg-(--color-popover) p-2 text-(--color-popover-foreground) shadow-xl',
+        'data-[state=closed]:animate-surface-out data-[state=open]:animate-surface-in',
+        className,
+      )}
+      style={
+        position == null ? { visibility: 'hidden' } : { top: position.top, left: position.left }
+      }
+      {...props}
+    />,
+    document.body,
+  );
+};
+
+type MenuItemProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const MenuItem = ({ className, onClick, type = 'button', ...props }: MenuItemProps) => {
+  const { setOpen } = useMenuContext();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+
+    setOpen(false);
+  };
+
+  return (
+    <button
+      type={type}
+      role="menuitem"
+      className={twMerge(
+        'flex cursor-pointer items-center rounded-xl px-3 py-2 text-sm text-(--color-foreground) transition-colors outline-none select-none',
+        'focus:bg-(--color-muted) data-[highlighted]:bg-(--color-muted)',
+        className,
+      )}
+      onClick={handleClick}
+      {...props}
+    />
+  );
+};
+
+type MenuLabelProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const MenuLabel = ({ className, ...props }: MenuLabelProps) => {
+  return (
+    <div
+      className={twMerge(
+        'px-3 py-2 text-xs font-semibold tracking-wide text-(--color-muted-foreground)',
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+type MenuSeparatorProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const MenuSeparator = ({ className, ...props }: MenuSeparatorProps) => {
+  return <div className={twMerge('my-1 h-px bg-(--color-border)', className)} {...props} />;
+};

--- a/packages/gocheok-project/src/components/navigation/menu/index.ts
+++ b/packages/gocheok-project/src/components/navigation/menu/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/navigation/menu/Menu';

--- a/packages/gocheok-project/src/components/navigation/tabs/Tabs.stories.tsx
+++ b/packages/gocheok-project/src/components/navigation/tabs/Tabs.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gocheok/components/navigation/tabs';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Navigation/Tabs/Default',
+  component: Tabs,
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-2xl p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+export const Default: Story = {
+  render: () => (
+    <Tabs defaultValue="overview">
+      <TabsList>
+        <TabsTrigger value="overview">개요</TabsTrigger>
+        <TabsTrigger value="schedule">일정</TabsTrigger>
+        <TabsTrigger value="members">참여자</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview">
+        <p className="text-sm leading-6 text-(--color-muted-foreground)">
+          프로젝트의 전체 상태와 최근 업데이트를 확인할 수 있습니다.
+        </p>
+      </TabsContent>
+      <TabsContent value="schedule">
+        <p className="text-sm leading-6 text-(--color-muted-foreground)">
+          주간 단위 일정과 마감일을 탭 전환으로 빠르게 비교할 수 있습니다.
+        </p>
+      </TabsContent>
+      <TabsContent value="members">
+        <p className="text-sm leading-6 text-(--color-muted-foreground)">
+          담당자, 리뷰어, 옵저버를 구분해 보여주는 정보 영역입니다.
+        </p>
+      </TabsContent>
+    </Tabs>
+  ),
+};

--- a/packages/gocheok-project/src/components/navigation/tabs/Tabs.tsx
+++ b/packages/gocheok-project/src/components/navigation/tabs/Tabs.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useId, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+type TabsContextValue = {
+  baseId: string;
+  value: string;
+  setValue: (nextValue: string) => void;
+};
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+const useTabsContext = () => {
+  const context = useContext(TabsContext);
+
+  if (context == null) {
+    throw new Error('Tabs 컴포넌트 내부에서만 사용할 수 있습니다.');
+  }
+
+  return context;
+};
+
+type TabsProps = React.HTMLAttributes<HTMLDivElement> & {
+  defaultValue?: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
+};
+
+export const Tabs = ({
+  children,
+  className,
+  defaultValue = '',
+  value: controlledValue,
+  onValueChange,
+  ...props
+}: TabsProps) => {
+  const generatedId = useId();
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+  const value = controlledValue ?? uncontrolledValue;
+
+  const setValue = useCallback(
+    (nextValue: string) => {
+      if (controlledValue == null) {
+        setUncontrolledValue(nextValue);
+      }
+
+      onValueChange?.(nextValue);
+    },
+    [controlledValue, onValueChange],
+  );
+
+  const contextValue = {
+    baseId: generatedId,
+    value,
+    setValue,
+  };
+
+  return (
+    <TabsContext.Provider value={contextValue}>
+      <div className={className} {...props}>
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+};
+
+type TabsListProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const TabsList = ({ className, ...props }: TabsListProps) => {
+  return (
+    <div
+      role="tablist"
+      className={twMerge(
+        'inline-flex items-center gap-1 rounded-xl bg-(--color-muted) p-1',
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+type TabsTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  value: string;
+};
+
+export const TabsTrigger = ({ className, onClick, value, ...props }: TabsTriggerProps) => {
+  const { baseId, value: selectedValue, setValue } = useTabsContext();
+  const isSelected = selectedValue === value;
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+
+    setValue(value);
+  };
+
+  return (
+    <button
+      id={`${baseId}-trigger-${value}`}
+      type="button"
+      role="tab"
+      aria-selected={isSelected}
+      aria-controls={`${baseId}-content-${value}`}
+      data-state={isSelected ? 'active' : 'inactive'}
+      className={twMerge(
+        'inline-flex min-w-24 cursor-pointer items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-(--color-muted-foreground) transition-colors',
+        'data-[state=active]:bg-white data-[state=active]:text-(--color-foreground) data-[state=active]:shadow-sm',
+        className,
+      )}
+      onClick={handleClick}
+      {...props}
+    />
+  );
+};
+
+type TabsContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  value: string;
+};
+
+export const TabsContent = ({ className, value, ...props }: TabsContentProps) => {
+  const { baseId, value: selectedValue } = useTabsContext();
+
+  if (selectedValue !== value) {
+    return null;
+  }
+
+  return (
+    <div
+      id={`${baseId}-content-${value}`}
+      role="tabpanel"
+      aria-labelledby={`${baseId}-trigger-${value}`}
+      className={twMerge(
+        'mt-4 rounded-2xl border border-(--color-border) bg-(--color-card) p-5 text-(--color-card-foreground) focus:outline-none',
+        className,
+      )}
+      {...props}
+    />
+  );
+};

--- a/packages/gocheok-project/src/components/navigation/tabs/index.ts
+++ b/packages/gocheok-project/src/components/navigation/tabs/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/navigation/tabs/Tabs';

--- a/packages/gocheok-project/src/tailwind.css
+++ b/packages/gocheok-project/src/tailwind.css
@@ -250,6 +250,8 @@ menu {
   --animate-overlay-show: overlay-show 0.2s ease-out;
   --animate-overlay-hide: overlay-hide 0.2s ease-out;
   --animate-content-show: content-show 0.2s ease-out;
+  --animate-surface-in: surface-in 0.16s cubic-bezier(0.16, 1, 0.3, 1);
+  --animate-surface-out: surface-out 0.12s ease-in;
   --animate-select-dialog-in: select-dialog-in 0.2s
     cubic-bezier(0.16, 1, 0.3, 1);
   --animate-select-dialog-out: select-dialog-out 0.15s ease-in;
@@ -281,6 +283,26 @@ menu {
     to {
       opacity: 1;
       transform: translate(-50%, -50%) scale(1);
+    }
+  }
+  @keyframes surface-in {
+    from {
+      opacity: 0;
+      transform: translateY(4px) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+  @keyframes surface-out {
+    from {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(4px) scale(0.98);
     }
   }
   @keyframes select-dialog-in {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,9 +554,6 @@ importers:
       '@gsap/react':
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.13.0)(react@19.2.0)
-      '@radix-ui/react-dialog':
-        specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tailwindcss/vite':
         specifier: catalog:tailwindcss
         version: 4.1.10(vite@5.4.19(@types/node@24.10.1)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.44.1))
@@ -13061,7 +13058,7 @@ snapshots:
       '@typescript-eslint/parser': 8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.29.0(jiti@2.6.1))
@@ -13105,7 +13102,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -13130,14 +13127,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -13188,7 +13185,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## 요약
- `packages/gocheok-project`에 커스텀 `Dialog`, `Tooltip`, `Popover`, `Tabs`, `Menu` 컴포넌트를 추가했습니다.
- 기존 `SelectDialog`의 Radix 의존을 제거하고 패키지 내부 오버레이 처리로 대체했습니다.
- `@radix-ui/*` 의존성을 제거해 패키지 동작을 자체 구현으로 정리했습니다.

## 테스트 계획
- [x] `pnpm exec eslint src/components/feedback/dialog/Dialog.tsx src/components/feedback/tooltip/Tooltip.tsx src/components/feedback/popover/Popover.tsx src/components/navigation/menu/Menu.tsx src/components/navigation/tabs/Tabs.tsx src/components/forms/select/SelectDialog.tsx --fix`
- [x] `pnpm --filter gocheok-project build`