### PR TITLE
feat(gocheok-project): 피드백 상태 컴포넌트 추가

### DIFF
--- a/packages/gocheok-project/src/components/feedback/alert/Alert.stories.tsx
+++ b/packages/gocheok-project/src/components/feedback/alert/Alert.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Alert } from '@gocheok/components/feedback/alert';
+
+const meta: Meta<typeof Alert> = {
+  title: 'Feedback/Alert/Default',
+  component: Alert,
+  decorators: [
+    (Story) => (
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Alert>;
+
+export const Info: Story = {
+  args: {
+    tone: 'info',
+    title: '저장된 초안이 있습니다',
+    description: '이전 작업이 자동 저장되어 이어서 편집할 수 있습니다.',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    tone: 'error',
+    title: '요청 처리에 실패했습니다',
+    description: '잠시 후 다시 시도하거나 네트워크 상태를 확인해 주세요.',
+  },
+};

--- a/packages/gocheok-project/src/components/feedback/alert/Alert.tsx
+++ b/packages/gocheok-project/src/components/feedback/alert/Alert.tsx
@@ -1,0 +1,115 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const toneClassNames = {
+  info: 'border-(--color-blue-200) bg-(--color-blue-50) text-(--color-blue-900)',
+  success: 'border-(--color-green-200) bg-(--color-green-50) text-(--color-green-900)',
+  warning: 'border-(--color-yellow-200) bg-(--color-yellow-50) text-(--color-yellow-900)',
+  error: 'border-(--color-red-200) bg-(--color-red-50) text-(--color-red-900)',
+} as const;
+
+export type AlertTone = keyof typeof toneClassNames;
+
+export interface AlertProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  description?: string;
+  tone?: AlertTone;
+  icon?: ReactNode;
+}
+
+function AlertIcon({ tone }: { tone: AlertTone }) {
+  const strokeClassName =
+    tone === 'error'
+      ? 'stroke-(--color-red-600)'
+      : tone === 'warning'
+        ? 'stroke-(--color-yellow-800)'
+        : tone === 'success'
+          ? 'stroke-(--color-green-700)'
+          : 'stroke-(--color-blue-700)';
+
+  if (tone === 'success') {
+    return (
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className={twMerge('h-5 w-5 fill-none stroke-2', strokeClassName)}
+      >
+        <path d="M5 12.5L9.5 17L19 7.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    );
+  }
+
+  if (tone === 'warning') {
+    return (
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className={twMerge('h-5 w-5 fill-none stroke-2', strokeClassName)}
+      >
+        <path d="M12 8V13" strokeLinecap="round" />
+        <path d="M12 16.5H12.01" strokeLinecap="round" />
+        <path
+          d="M10.4 4.9L3.6 17.1C2.9 18.3 3.8 19.8 5.2 19.8H18.8C20.2 19.8 21.1 18.3 20.4 17.1L13.6 4.9C12.9 3.7 11.1 3.7 10.4 4.9Z"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+
+  if (tone === 'error') {
+    return (
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className={twMerge('h-5 w-5 fill-none stroke-2', strokeClassName)}
+      >
+        <circle cx="12" cy="12" r="8" />
+        <path d="M12 8V12.5" strokeLinecap="round" />
+        <path d="M12 16H12.01" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className={twMerge('h-5 w-5 fill-none stroke-2', strokeClassName)}
+    >
+      <circle cx="12" cy="12" r="8" />
+      <path d="M12 10V16" strokeLinecap="round" />
+      <path d="M12 7.5H12.01" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function Alert({
+  className,
+  title,
+  description,
+  tone = 'info',
+  icon,
+  children,
+  ...props
+}: AlertProps) {
+  return (
+    <div
+      role={tone === 'error' || tone === 'warning' ? 'alert' : 'status'}
+      aria-live={tone === 'error' ? 'assertive' : 'polite'}
+      className={twMerge(
+        'flex gap-3 rounded-2xl border p-4 shadow-sm',
+        toneClassNames[tone],
+        className,
+      )}
+      {...props}
+    >
+      <div className="mt-0.5 shrink-0">{icon ?? <AlertIcon tone={tone} />}</div>
+      <div className="min-w-0">
+        <p className="text-sm font-semibold">{title}</p>
+        {description ? <p className="mt-1 text-sm leading-6 opacity-80">{description}</p> : null}
+        {children ? <div className="mt-3">{children}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/gocheok-project/src/components/feedback/alert/index.ts
+++ b/packages/gocheok-project/src/components/feedback/alert/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/feedback/alert/Alert';

--- a/packages/gocheok-project/src/components/feedback/emptyState/EmptyState.stories.tsx
+++ b/packages/gocheok-project/src/components/feedback/emptyState/EmptyState.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '@gocheok/components/actions/button/Button';
+import { EmptyState } from '@gocheok/components/feedback/emptyState';
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'Feedback/EmptyState/Default',
+  component: EmptyState,
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-2xl p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+export const SearchResultEmpty: Story = {
+  args: {
+    title: '검색 결과가 없어요',
+    description: '필터를 조금 넓히거나 다른 키워드로 다시 찾아보세요.',
+    action: (
+      <Button className="rounded-lg bg-(--color-primary) px-4 py-2 text-sm text-white">
+        필터 초기화
+      </Button>
+    ),
+  },
+};
+
+export const ListEmpty: Story = {
+  args: {
+    title: '아직 등록된 항목이 없습니다',
+    description: '첫 번째 항목을 추가하면 이 영역에서 목록과 상태를 확인할 수 있습니다.',
+    action: (
+      <Button className="rounded-lg bg-(--color-secondary) px-4 py-2 text-sm text-(--color-foreground)">
+        새 항목 만들기
+      </Button>
+    ),
+  },
+};

--- a/packages/gocheok-project/src/components/feedback/emptyState/EmptyState.tsx
+++ b/packages/gocheok-project/src/components/feedback/emptyState/EmptyState.tsx
@@ -1,0 +1,43 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { Card } from '@gocheok/components/presenter/card/Card';
+import emptyStateIllustration from '@gocheok/components/feedback/emptyState/empty-state-illustration.svg';
+import { twMerge } from 'tailwind-merge';
+
+export interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  description?: string;
+  imageSrc?: string;
+  imageAlt?: string;
+  action?: ReactNode;
+}
+
+export function EmptyState({
+  className,
+  title,
+  description,
+  imageSrc = emptyStateIllustration,
+  imageAlt = '',
+  action,
+  ...props
+}: EmptyStateProps) {
+  return (
+    <Card className={twMerge('px-6 py-10', className)} {...props}>
+      <div className="flex flex-col items-center text-center">
+        <img
+          src={imageSrc}
+          alt={imageAlt}
+          aria-hidden={imageAlt === '' ? 'true' : undefined}
+          className="h-40 w-60 object-contain"
+        />
+        <h3 className="mt-3 text-xl font-semibold text-(--color-foreground)">{title}</h3>
+        {description ? (
+          <p className="mt-2 max-w-md text-sm leading-6 text-(--color-muted-foreground)">
+            {description}
+          </p>
+        ) : null}
+        {action ? <div className="mt-6">{action}</div> : null}
+      </div>
+    </Card>
+  );
+}

--- a/packages/gocheok-project/src/components/feedback/emptyState/empty-state-illustration.svg
+++ b/packages/gocheok-project/src/components/feedback/emptyState/empty-state-illustration.svg
@@ -1,0 +1,11 @@
+<svg width="240" height="160" viewBox="0 0 240 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="36" y="30" width="128" height="88" rx="18" fill="#F2F4F6"/>
+  <rect x="54" y="48" width="92" height="12" rx="6" fill="#D1D6DB"/>
+  <rect x="54" y="68" width="72" height="12" rx="6" fill="#E5E8EB"/>
+  <rect x="54" y="88" width="56" height="12" rx="6" fill="#E5E8EB"/>
+  <path d="M165 104C181.016 104 194 91.0163 194 75C194 58.9837 181.016 46 165 46C148.984 46 136 58.9837 136 75C136 91.0163 148.984 104 165 104Z" fill="#E8F3FF"/>
+  <path d="M177.348 95.748L197.5 115.9" stroke="#3182F6" stroke-width="10" stroke-linecap="round"/>
+  <path d="M165 91C173.837 91 181 83.8366 181 75C181 66.1634 173.837 59 165 59C156.163 59 149 66.1634 149 75C149 83.8366 156.163 91 165 91Z" stroke="#3182F6" stroke-width="8"/>
+  <circle cx="63" cy="131" r="9" fill="#E8F3FF"/>
+  <circle cx="86" cy="137" r="5" fill="#D1E6FF"/>
+</svg>

--- a/packages/gocheok-project/src/components/feedback/emptyState/index.ts
+++ b/packages/gocheok-project/src/components/feedback/emptyState/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/feedback/emptyState/EmptyState';

--- a/packages/gocheok-project/src/components/feedback/skeleton/Skeleton.stories.tsx
+++ b/packages/gocheok-project/src/components/feedback/skeleton/Skeleton.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Card } from '@gocheok/components/presenter/card/Card';
+import { Skeleton } from '@gocheok/components/feedback/skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Feedback/Skeleton/Default',
+  component: Skeleton,
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-2xl p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  render: () => (
+    <Card className="space-y-4">
+      <div className="flex items-center gap-4">
+        <Skeleton shape="circle" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="w-40" />
+          <Skeleton className="w-24" />
+        </div>
+      </div>
+      <Skeleton shape="rect" className="h-40" />
+      <Skeleton />
+      <Skeleton className="w-5/6" />
+      <Skeleton className="w-2/3" />
+    </Card>
+  ),
+};

--- a/packages/gocheok-project/src/components/feedback/skeleton/Skeleton.tsx
+++ b/packages/gocheok-project/src/components/feedback/skeleton/Skeleton.tsx
@@ -1,0 +1,29 @@
+import type { HTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const shapeClassNames = {
+  line: 'h-4 w-full rounded-md',
+  rect: 'h-24 w-full rounded-xl',
+  circle: 'h-12 w-12 rounded-full',
+} as const;
+
+export type SkeletonShape = keyof typeof shapeClassNames;
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  shape?: SkeletonShape;
+}
+
+export function Skeleton({ className, shape = 'line', ...props }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={twMerge(
+        'animate-pulse bg-linear-to-r from-(--color-grey-100) via-(--color-grey-200) to-(--color-grey-100) bg-[length:200%_100%]',
+        shapeClassNames[shape],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/gocheok-project/src/components/feedback/skeleton/index.ts
+++ b/packages/gocheok-project/src/components/feedback/skeleton/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/feedback/skeleton/Skeleton';

--- a/packages/gocheok-project/src/components/feedback/spinner/Spinner.stories.tsx
+++ b/packages/gocheok-project/src/components/feedback/spinner/Spinner.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Card } from '@gocheok/components/presenter/card/Card';
+import { Spinner } from '@gocheok/components/feedback/spinner';
+
+const meta: Meta<typeof Spinner> = {
+  title: 'Feedback/Spinner/Default',
+  component: Spinner,
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-64 items-center justify-center p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Spinner>;
+
+export const Default: Story = {
+  args: {
+    label: '데이터를 불러오는 중입니다.',
+  },
+};
+
+export const PageLoading: Story = {
+  render: () => (
+    <Card className="flex w-full max-w-md flex-col items-center gap-4 py-12">
+      <Spinner size="lg" label="콘텐츠를 준비하고 있습니다." />
+      <p className="text-sm text-(--color-muted-foreground)">
+        네트워크 상태에 따라 최대 몇 초 정도 걸릴 수 있습니다.
+      </p>
+    </Card>
+  ),
+};

--- a/packages/gocheok-project/src/components/feedback/spinner/Spinner.tsx
+++ b/packages/gocheok-project/src/components/feedback/spinner/Spinner.tsx
@@ -1,0 +1,59 @@
+import type { HTMLAttributes } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const sizeClassNames = {
+  sm: 'h-4 w-4 border-2',
+  md: 'h-6 w-6 border-2',
+  lg: 'h-8 w-8 border-[3px]',
+} as const;
+
+const toneClassNames = {
+  primary: 'border-(--color-blue-100) border-t-(--color-primary)',
+  neutral: 'border-(--color-grey-200) border-t-(--color-grey-600)',
+  inverse: 'border-white/20 border-t-white',
+} as const;
+
+export type SpinnerSize = keyof typeof sizeClassNames;
+export type SpinnerTone = keyof typeof toneClassNames;
+
+export interface SpinnerProps extends HTMLAttributes<HTMLDivElement> {
+  size?: SpinnerSize;
+  tone?: SpinnerTone;
+  label?: string;
+  hideLabel?: boolean;
+}
+
+export function Spinner({
+  className,
+  size = 'md',
+  tone = 'primary',
+  label = '로딩 중',
+  hideLabel = false,
+  ...props
+}: SpinnerProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={twMerge('inline-flex items-center gap-3', className)}
+      {...props}
+    >
+      <span
+        aria-hidden="true"
+        className={twMerge(
+          'inline-block animate-spin rounded-full border-solid',
+          sizeClassNames[size],
+          toneClassNames[tone],
+        )}
+      />
+      <span className={hideLabel ? 'sr-only' : 'text-sm text-(--color-muted-foreground)'}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export function Loader(props: SpinnerProps) {
+  return <Spinner {...props} />;
+}

--- a/packages/gocheok-project/src/components/feedback/spinner/index.ts
+++ b/packages/gocheok-project/src/components/feedback/spinner/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/feedback/spinner/Spinner';

--- a/packages/gocheok-project/src/components/feedback/toast/Toast.stories.tsx
+++ b/packages/gocheok-project/src/components/feedback/toast/Toast.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '@gocheok/components/actions/button/Button';
+import { Toast, ToastAction } from '@gocheok/components/feedback/toast';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Feedback/Toast/Default',
+  component: Toast,
+  decorators: [
+    (Story) => (
+      <div className="mx-auto flex min-h-72 w-full max-w-2xl items-start justify-center p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Toast>;
+
+function ToastExample() {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="flex w-full flex-col items-start gap-4">
+      <Button
+        className="rounded-lg bg-(--color-primary) px-4 py-2 text-sm text-white"
+        onClick={() => setOpen(true)}
+      >
+        토스트 다시 열기
+      </Button>
+      {open ? (
+        <Toast
+          floating={false}
+          tone="success"
+          title="게시가 완료되었습니다"
+          description="방금 등록한 글이 메인 화면에 노출되기 시작했습니다."
+          action={<ToastAction>자세히 보기</ToastAction>}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ToastExample />,
+};

--- a/packages/gocheok-project/src/components/feedback/toast/Toast.tsx
+++ b/packages/gocheok-project/src/components/feedback/toast/Toast.tsx
@@ -1,0 +1,117 @@
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from 'react';
+
+import { twMerge } from 'tailwind-merge';
+
+const toneClassNames = {
+  info: 'border-(--color-blue-200) bg-white text-(--color-foreground)',
+  success: 'border-(--color-green-200) bg-white text-(--color-foreground)',
+  warning: 'border-(--color-yellow-200) bg-white text-(--color-foreground)',
+  error: 'border-(--color-red-200) bg-white text-(--color-foreground)',
+} as const;
+
+const positionClassNames = {
+  topRight: 'top-6 right-6',
+  topLeft: 'top-6 left-6',
+  bottomRight: 'right-6 bottom-6',
+  bottomLeft: 'bottom-6 left-6',
+} as const;
+
+export type ToastTone = keyof typeof toneClassNames;
+export type ToastPosition = keyof typeof positionClassNames;
+
+export interface ToastActionProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+}
+
+export function ToastAction({ className, type = 'button', ...props }: ToastActionProps) {
+  return (
+    <button
+      type={type}
+      className={twMerge(
+        'cursor-pointer rounded-lg px-3 py-2 text-sm font-medium text-(--color-primary)',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface ToastProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  description?: string;
+  tone?: ToastTone;
+  floating?: boolean;
+  position?: ToastPosition;
+  action?: ReactNode;
+  onClose?: () => void;
+}
+
+function ToastAccent({ tone }: { tone: ToastTone }) {
+  const backgroundClassName =
+    tone === 'error'
+      ? 'bg-(--color-red-500)'
+      : tone === 'warning'
+        ? 'bg-(--color-yellow-500)'
+        : tone === 'success'
+          ? 'bg-(--color-green-500)'
+          : 'bg-(--color-blue-500)';
+
+  return (
+    <span
+      aria-hidden="true"
+      className={twMerge('mt-1 h-3 w-3 rounded-full', backgroundClassName)}
+    />
+  );
+}
+
+export function Toast({
+  className,
+  title,
+  description,
+  tone = 'info',
+  floating = true,
+  position = 'topRight',
+  action,
+  onClose,
+  ...props
+}: ToastProps) {
+  return (
+    <div
+      role={tone === 'error' ? 'alert' : 'status'}
+      aria-live={tone === 'error' ? 'assertive' : 'polite'}
+      className={twMerge(
+        'flex w-full max-w-sm gap-3 rounded-2xl border px-4 py-4 shadow-lg',
+        toneClassNames[tone],
+        floating ? twMerge('fixed z-[220]', positionClassNames[position]) : 'relative',
+        className,
+      )}
+      {...props}
+    >
+      <ToastAccent tone={tone} />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold">{title}</p>
+        {description ? (
+          <p className="mt-1 text-sm leading-6 text-(--color-muted-foreground)">{description}</p>
+        ) : null}
+        {action ? <div className="mt-3">{action}</div> : null}
+      </div>
+      {onClose ? (
+        <button
+          type="button"
+          onClick={onClose}
+          className="cursor-pointer rounded-full p-1 text-(--color-muted-foreground) transition-colors hover:bg-(--color-muted)"
+          aria-label="토스트 닫기"
+        >
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            className="h-4 w-4 fill-none stroke-current stroke-2"
+          >
+            <path d="M6 6L18 18" strokeLinecap="round" />
+            <path d="M18 6L6 18" strokeLinecap="round" />
+          </svg>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/gocheok-project/src/components/feedback/toast/index.ts
+++ b/packages/gocheok-project/src/components/feedback/toast/index.ts
@@ -1,0 +1,1 @@
+export * from '@gocheok/components/feedback/toast/Toast';


### PR DESCRIPTION
## 요약
- `packages/gocheok-project`에 `Spinner`, `Skeleton`, `EmptyState`, `Alert`, `Toast` 컴포넌트를 추가했습니다.
- 로딩, 빈 상태, 인라인 알림, 토스트 상태를 확인할 수 있는 Storybook 예시를 함께 구성했습니다.
- `EmptyState`에 사용할 일러스트를 `svg` 에셋으로 추가했습니다.

## 테스트 계획
- [x] `pnpm exec eslint src/components/feedback/alert/Alert.tsx src/components/feedback/alert/Alert.stories.tsx src/components/feedback/emptyState/EmptyState.tsx src/components/feedback/emptyState/EmptyState.stories.tsx src/components/feedback/spinner/Spinner.tsx src/components/feedback/spinner/Spinner.stories.tsx src/components/feedback/skeleton/Skeleton.tsx src/components/feedback/skeleton/Skeleton.stories.tsx src/components/feedback/toast/Toast.tsx src/components/feedback/toast/Toast.stories.tsx --fix`
- [x] `pnpm --filter gocheok-project build`


Made with [Cursor](https://cursor.com)