### PR TITLE
feat(gocheok-project): datepicker 컴포넌트 추가

### DIFF
--- a/packages/gocheok-project/index.ts
+++ b/packages/gocheok-project/index.ts
@@ -22,6 +22,7 @@ export * from './src/components/forms/label';
 export * from './src/components/forms/radio';
 export * from './src/components/forms/switch';
 export * from './src/components/forms/select';
+export * from './src/components/forms/datepicker';
 
 // presenter
 export * from './src/components/presenter/avatar';

--- a/packages/gocheok-project/package.json
+++ b/packages/gocheok-project/package.json
@@ -19,6 +19,7 @@
     "@gsap/react": "^2.1.2",
     "@tailwindcss/vite": "catalog:tailwindcss",
     "gsap": "^3.13.0",
+    "dayjs": "catalog:date",
     "react": "catalog:react",
     "react-confetti": "^6.4.0",
     "react-dom": "catalog:react",

--- a/packages/gocheok-project/src/components/forms/datepicker/DatePicker.stories.tsx
+++ b/packages/gocheok-project/src/components/forms/datepicker/DatePicker.stories.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { DatePicker } from '@gocheok/components/forms/datepicker/DatePicker';
+import type { DatePickerValue } from '@gocheok/components/forms/datepicker/types';
+import { Label } from '@gocheok/components/forms/label/Label';
+
+const meta: Meta<typeof DatePicker> = {
+  title: 'Forms/DatePicker/Default',
+  component: DatePicker,
+  decorators: [
+    (Story) => (
+      <div className="max-w-full p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DatePicker>;
+
+const today = new Date();
+const addDays = (date: Date, count: number) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate() + count);
+
+const ControlledExample = () => {
+  const [value, setValue] = useState<DatePickerValue>(today);
+
+  return (
+    <div className="flex max-w-xs flex-col gap-3">
+      <DatePicker value={value} onChange={setValue} />
+      <p className="text-sm text-(--color-grey-600)">
+        선택값: {value == null ? '없음' : value.toLocaleDateString('ko-KR')}
+      </p>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => (
+    <div className="max-w-xs">
+      <DatePicker defaultValue={today} placeholder="YYYY-MM-DD" />
+    </div>
+  ),
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <div className="flex max-w-xs flex-col gap-2">
+      <Label htmlFor="story-datepicker">생년월일</Label>
+      <DatePicker id="story-datepicker" name="birthday" placeholder="YYYY-MM-DD" />
+    </div>
+  ),
+};
+
+export const Controlled: Story = {
+  render: () => <ControlledExample />,
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="max-w-xs">
+      <DatePicker disabled defaultValue={today} />
+    </div>
+  ),
+};
+
+export const MinMax: Story = {
+  render: () => (
+    <div className="max-w-xs">
+      <DatePicker defaultValue={today} maxDate={addDays(today, 30)} minDate={addDays(today, -30)} />
+    </div>
+  ),
+};
+
+export const Locale_KO: Story = {
+  render: () => (
+    <div className="max-w-xs">
+      <DatePicker defaultValue={today} locale="ko" />
+    </div>
+  ),
+};
+
+export const Locale_EN: Story = {
+  render: () => (
+    <div className="max-w-xs">
+      <DatePicker defaultValue={today} locale="en" />
+    </div>
+  ),
+};
+
+export const IsDateDisabled: Story = {
+  render: () => (
+    <div className="max-w-xs">
+      <DatePicker
+        defaultValue={today}
+        isDateDisabled={(date) => date.getDay() === 0 || date.getDay() === 6}
+      />
+    </div>
+  ),
+};
+
+export const CustomMonthIcons: Story = {
+  render: () => (
+    <div className="max-w-xs">
+      <DatePicker
+        defaultValue={today}
+        nextMonthIcon={<span aria-hidden="true">→</span>}
+        previousMonthIcon={<span aria-hidden="true">←</span>}
+      />
+    </div>
+  ),
+};

--- a/packages/gocheok-project/src/components/forms/datepicker/DatePicker.tsx
+++ b/packages/gocheok-project/src/components/forms/datepicker/DatePicker.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useCallback, useEffect, useId, useRef } from 'react';
+
+import { DatePickerCalendar } from '@gocheok/components/forms/datepicker/DatePickerCalendar';
+import {
+  DatePickerProvider,
+  useDatePickerContext,
+} from '@gocheok/components/forms/datepicker/DatePickerContext';
+import { DatePickerDialog } from '@gocheok/components/forms/datepicker/DatePickerDialog';
+import { DatePickerTrigger } from '@gocheok/components/forms/datepicker/DatePickerTrigger';
+import type { DatePickerProps, DatePickerValue } from '@gocheok/components/forms/datepicker/types';
+import {
+  clampDate,
+  isSameDay,
+  startOfMonth,
+} from '@gocheok/components/forms/datepicker/utils/date';
+
+type DatePickerInnerProps = Required<Pick<DatePickerProps, 'format' | 'locale' | 'weekStartsOn'>> &
+  Omit<DatePickerProps, 'format' | 'locale' | 'weekStartsOn' | 'defaultValue'> & {
+    isControlled: boolean;
+  };
+
+const DatePickerInner = ({
+  value,
+  onChange,
+  format,
+  minDate,
+  maxDate,
+  isDateDisabled,
+  weekStartsOn,
+  locale,
+  placeholder,
+  id,
+  name,
+  disabled,
+  required,
+  className,
+  ref,
+  previousMonthIcon,
+  nextMonthIcon,
+  isControlled,
+}: DatePickerInnerProps) => {
+  const { dispatch } = useDatePickerContext();
+  const dialogId = useId();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const isDateAllowed = useCallback(
+    (date: Date) => {
+      const boundedDate = clampDate(date, minDate, maxDate);
+
+      if (!isSameDay(date, boundedDate)) {
+        return false;
+      }
+
+      return isDateDisabled?.(date) !== true;
+    },
+    [isDateDisabled, maxDate, minDate],
+  );
+
+  const commitValue = useCallback(
+    (next: DatePickerValue) => {
+      if (next != null && !isDateAllowed(next)) return;
+
+      if (!isControlled) {
+        dispatch({ type: 'SET_VALUE', date: next });
+      }
+
+      if (next != null) {
+        dispatch({ type: 'SET_VISIBLE_MONTH', date: startOfMonth(next) });
+        dispatch({ type: 'SET_FOCUSED_DATE', date: next });
+      }
+
+      onChange?.(next);
+    },
+    [dispatch, isControlled, isDateAllowed, onChange],
+  );
+
+  useEffect(() => {
+    if (!isControlled) return;
+
+    dispatch({ type: 'SET_VALUE', date: value ?? null });
+
+    if (value != null) {
+      dispatch({ type: 'SET_VISIBLE_MONTH', date: startOfMonth(value) });
+      dispatch({ type: 'SET_FOCUSED_DATE', date: value });
+    }
+  }, [dispatch, isControlled, value]);
+
+  return (
+    <>
+      <DatePickerTrigger
+        ref={ref}
+        className={className}
+        dialogId={dialogId}
+        disabled={disabled}
+        format={format}
+        id={id}
+        inputRef={inputRef}
+        isDateAllowed={isDateAllowed}
+        locale={locale}
+        name={name}
+        placeholder={placeholder}
+        required={required}
+        onCommit={commitValue}
+      />
+      <DatePickerDialog id={dialogId} inputRef={inputRef} locale={locale}>
+        <DatePickerCalendar
+          inputRef={inputRef}
+          isDateAllowed={isDateAllowed}
+          locale={locale}
+          maxDate={maxDate}
+          minDate={minDate}
+          nextMonthIcon={nextMonthIcon}
+          previousMonthIcon={previousMonthIcon}
+          weekStartsOn={weekStartsOn}
+          onCommit={commitValue}
+        />
+      </DatePickerDialog>
+    </>
+  );
+};
+
+export const DatePicker = ({
+  value,
+  defaultValue,
+  format = 'YYYY-MM-DD',
+  weekStartsOn = 0,
+  locale = 'ko',
+  ...props
+}: DatePickerProps) => {
+  const hasWarnedRef = useRef(false);
+  const isControlled = value !== undefined;
+  const initialValue = isControlled ? value : defaultValue;
+
+  useEffect(() => {
+    if (!isControlled || defaultValue === undefined || hasWarnedRef.current) return;
+
+    console.warn(
+      'DatePicker는 value와 defaultValue를 동시에 받았습니다. 제어 모드(value)를 우선합니다.',
+    );
+    hasWarnedRef.current = true;
+  }, [defaultValue, isControlled]);
+
+  return (
+    <DatePickerProvider
+      defaultValue={initialValue ?? null}
+      format={format}
+      maxDate={props.maxDate}
+      minDate={props.minDate}
+      weekStartsOn={weekStartsOn}
+    >
+      <DatePickerInner
+        {...props}
+        value={value}
+        format={format}
+        isControlled={isControlled}
+        locale={locale}
+        weekStartsOn={weekStartsOn}
+      />
+    </DatePickerProvider>
+  );
+};

--- a/packages/gocheok-project/src/components/forms/datepicker/DatePickerCalendar.tsx
+++ b/packages/gocheok-project/src/components/forms/datepicker/DatePickerCalendar.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { useDatePickerContext } from '@gocheok/components/forms/datepicker/DatePickerContext';
+import type { DatePickerValue } from '@gocheok/components/forms/datepicker/types';
+import {
+  addDays,
+  addMonths,
+  buildMonthMatrix,
+  clampDate,
+  formatDate,
+  isSameDay,
+  isSameMonth,
+  startOfMonth,
+} from '@gocheok/components/forms/datepicker/utils/date';
+
+type DatePickerCalendarProps = {
+  locale: string;
+  minDate?: Date;
+  maxDate?: Date;
+  weekStartsOn: 0 | 1;
+  isDateAllowed: (date: Date) => boolean;
+  onCommit: (next: DatePickerValue) => void;
+  inputRef: React.MutableRefObject<HTMLInputElement | null>;
+  previousMonthIcon?: React.ReactNode;
+  nextMonthIcon?: React.ReactNode;
+};
+
+const getDateKey = (date: Date) => formatDate(date, 'YYYY-MM-DD');
+
+const defaultPreviousMonthIcon = (
+  <svg aria-hidden="true" className="size-4" fill="none" viewBox="0 0 24 24">
+    <path
+      d="M15 18 9 12l6-6"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
+const defaultNextMonthIcon = (
+  <svg aria-hidden="true" className="size-4" fill="none" viewBox="0 0 24 24">
+    <path
+      d="m9 6 6 6-6 6"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
+export const DatePickerCalendar = ({
+  locale,
+  minDate,
+  maxDate,
+  weekStartsOn,
+  isDateAllowed,
+  onCommit,
+  inputRef,
+  previousMonthIcon = defaultPreviousMonthIcon,
+  nextMonthIcon = defaultNextMonthIcon,
+}: DatePickerCalendarProps) => {
+  const { state, dispatch } = useDatePickerContext();
+  const focusedButtonRef = useRef<HTMLButtonElement | null>(null);
+  const today = useMemo(() => new Date(), []);
+  const monthLabelFormat = locale === 'ko' ? 'YYYY년 M월' : 'MMMM YYYY';
+  const monthLabel = formatDate(state.visibleMonth, monthLabelFormat, locale);
+  const monthMatrix = useMemo(
+    () => buildMonthMatrix({ visibleMonth: state.visibleMonth, weekStartsOn }),
+    [state.visibleMonth, weekStartsOn],
+  );
+  const weekdayLabels = useMemo(() => {
+    return Array.from({ length: 7 }, (_item, index) => {
+      const day = addDays(new Date(2026, 2, 1), weekStartsOn + index);
+
+      return dayjs(day).locale(locale).format('dd');
+    });
+  }, [locale, weekStartsOn]);
+
+  const focusDate = (nextDate: Date) => {
+    const clamped = clampDate(nextDate, minDate, maxDate);
+
+    dispatch({ type: 'SET_FOCUSED_DATE', date: clamped });
+    dispatch({ type: 'SET_VISIBLE_MONTH', date: startOfMonth(clamped) });
+  };
+
+  const commitDate = (date: Date) => {
+    if (!isDateAllowed(date)) return;
+
+    onCommit(date);
+    dispatch({ type: 'SET_FOCUSED_DATE', date });
+    dispatch({ type: 'SET_VISIBLE_MONTH', date });
+    dispatch({ type: 'SET_OPEN', open: false });
+    inputRef.current?.focus();
+  };
+
+  useEffect(() => {
+    if (!state.isOpen) return;
+
+    focusedButtonRef.current?.focus();
+  }, [state.focusedDate, state.isOpen]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const current = state.focusedDate;
+    let nextDate: Date;
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        nextDate = addDays(current, -1);
+        break;
+      case 'ArrowRight':
+        nextDate = addDays(current, 1);
+        break;
+      case 'ArrowUp':
+        nextDate = addDays(current, -7);
+        break;
+      case 'ArrowDown':
+        nextDate = addDays(current, 7);
+        break;
+      case 'PageUp':
+        nextDate = addMonths(current, event.shiftKey ? -12 : -1);
+        break;
+      case 'PageDown':
+        nextDate = addMonths(current, event.shiftKey ? 12 : 1);
+        break;
+      case 'Home': {
+        const dayOffset = (dayjs(current).day() - weekStartsOn + 7) % 7;
+        nextDate = addDays(current, -dayOffset);
+        break;
+      }
+      case 'End': {
+        const dayOffset = (dayjs(current).day() - weekStartsOn + 7) % 7;
+        nextDate = addDays(current, 6 - dayOffset);
+        break;
+      }
+      case 'Enter':
+        event.preventDefault();
+        commitDate(current);
+        return;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+
+    focusDate(nextDate);
+  };
+
+  return (
+    <div className="w-72 p-3 sm:w-80" onKeyDown={handleKeyDown}>
+      <div className="mb-2 flex h-10 items-center justify-between gap-2">
+        <button
+          type="button"
+          aria-label="이전 달"
+          className="inline-flex size-8 items-center justify-center rounded-md text-(--color-foreground) transition-colors duration-200 ease-in-out hover:bg-(--color-grey-100)"
+          onClick={() => focusDate(addMonths(state.visibleMonth, -1))}
+        >
+          {previousMonthIcon}
+        </button>
+        <div aria-live="polite" className="font-medium text-(--color-foreground)">
+          {monthLabel}
+        </div>
+        <button
+          type="button"
+          aria-label="다음 달"
+          className="inline-flex size-8 items-center justify-center rounded-md text-(--color-foreground) transition-colors duration-200 ease-in-out hover:bg-(--color-grey-100)"
+          onClick={() => focusDate(addMonths(state.visibleMonth, 1))}
+        >
+          {nextMonthIcon}
+        </button>
+      </div>
+      <div role="grid" aria-label={monthLabel} className="grid grid-cols-7 gap-1">
+        {weekdayLabels.map((label) => (
+          <div
+            key={label}
+            role="columnheader"
+            className="flex h-8 items-center justify-center text-xs font-medium text-(--color-grey-500)"
+          >
+            {label}
+          </div>
+        ))}
+        {monthMatrix.flat().map((date) => {
+          const disabled = !isDateAllowed(date);
+          const isFocused = isSameDay(date, state.focusedDate);
+          const isSelected = state.value != null && isSameDay(date, state.value);
+          const isToday = isSameDay(date, today);
+          const isOutsideMonth = !isSameMonth(date, state.visibleMonth);
+
+          return (
+            <button
+              key={getDateKey(date)}
+              ref={isFocused ? focusedButtonRef : undefined}
+              type="button"
+              role="gridcell"
+              aria-current={isToday ? 'date' : undefined}
+              aria-disabled={disabled}
+              aria-selected={isSelected}
+              tabIndex={isFocused ? 0 : -1}
+              className={twMerge(
+                'flex size-9 items-center justify-center rounded-md text-sm text-(--color-foreground) transition-colors duration-200 ease-in-out sm:size-10',
+                'focus-visible:ring-2 focus-visible:ring-(--color-primary) focus-visible:outline-none',
+                !disabled && 'hover:bg-(--color-grey-100)',
+                isToday && 'ring-1 ring-(--color-primary)',
+                isSelected &&
+                  'bg-(--color-primary) text-(--color-neutral-100) hover:bg-(--color-primary)',
+                isOutsideMonth && !isSelected && 'text-(--color-grey-400)',
+                disabled && 'cursor-not-allowed text-(--color-grey-300)',
+              )}
+              onClick={() => commitDate(date)}
+            >
+              {formatDate(date, 'D', locale)}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/gocheok-project/src/components/forms/datepicker/DatePickerContext.tsx
+++ b/packages/gocheok-project/src/components/forms/datepicker/DatePickerContext.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useMemo, useReducer } from 'react';
+
+import type { PopupPixelPosition } from '@gocheok/components/forms/select/types';
+import type { DatePickerValue } from '@gocheok/components/forms/datepicker/types';
+import { clampDate, startOfMonth } from '@gocheok/components/forms/datepicker/utils/date';
+
+export type DatePickerState = {
+  value: DatePickerValue;
+  visibleMonth: Date;
+  focusedDate: Date;
+  dialogPosition: PopupPixelPosition | null;
+  isOpen: boolean;
+};
+
+export type DatePickerAction =
+  | { type: 'SET_VALUE'; date: DatePickerValue }
+  | { type: 'SET_VISIBLE_MONTH'; date: Date }
+  | { type: 'SET_FOCUSED_DATE'; date: Date }
+  | { type: 'SET_DIALOG_POSITION'; position: PopupPixelPosition | null }
+  | { type: 'SET_OPEN'; open: boolean };
+
+type CreateInitialStateParams = {
+  defaultValue?: DatePickerValue;
+  format: string;
+  weekStartsOn: 0 | 1;
+  minDate?: Date;
+  maxDate?: Date;
+};
+
+export const createInitialState = ({
+  defaultValue = null,
+  minDate,
+  maxDate,
+}: CreateInitialStateParams): DatePickerState => {
+  const today = clampDate(new Date(), minDate, maxDate);
+  const value = defaultValue == null ? null : clampDate(defaultValue, minDate, maxDate);
+  const focusedDate = value ?? today;
+
+  return {
+    value,
+    visibleMonth: startOfMonth(focusedDate),
+    focusedDate,
+    dialogPosition: null,
+    isOpen: false,
+  };
+};
+
+const datePickerReducer = (state: DatePickerState, action: DatePickerAction): DatePickerState => {
+  switch (action.type) {
+    case 'SET_VALUE':
+      return { ...state, value: action.date };
+    case 'SET_VISIBLE_MONTH':
+      return { ...state, visibleMonth: startOfMonth(action.date) };
+    case 'SET_FOCUSED_DATE':
+      return { ...state, focusedDate: action.date };
+    case 'SET_DIALOG_POSITION':
+      return { ...state, dialogPosition: action.position };
+    case 'SET_OPEN':
+      return { ...state, isOpen: action.open };
+    default:
+      return state;
+  }
+};
+
+export type DatePickerContextValue = {
+  state: DatePickerState;
+  dispatch: React.Dispatch<DatePickerAction>;
+};
+
+export type DatePickerProviderProps = React.PropsWithChildren<CreateInitialStateParams>;
+
+const DatePickerContext = createContext<DatePickerContextValue | null>(null);
+
+export const DatePickerProvider = ({ children, ...initialParams }: DatePickerProviderProps) => {
+  const [state, dispatch] = useReducer(datePickerReducer, initialParams, createInitialState);
+  const contextValue = useMemo(() => ({ state, dispatch }), [state, dispatch]);
+
+  return <DatePickerContext.Provider value={contextValue}>{children}</DatePickerContext.Provider>;
+};
+
+export const useDatePickerContext = (): DatePickerContextValue => {
+  const ctx = useContext(DatePickerContext);
+
+  if (ctx == null) {
+    throw new Error('useDatePickerContext는 DatePickerProvider 트리 안에서만 사용할 수 있습니다.');
+  }
+
+  return ctx;
+};

--- a/packages/gocheok-project/src/components/forms/datepicker/DatePickerDialog.tsx
+++ b/packages/gocheok-project/src/components/forms/datepicker/DatePickerDialog.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useDatePickerContext } from '@gocheok/components/forms/datepicker/DatePickerContext';
+
+type DatePickerDialogProps = {
+  id: string;
+  locale: string;
+  children: React.ReactNode;
+  inputRef: React.MutableRefObject<HTMLInputElement | null>;
+};
+
+export const DatePickerDialog = ({ id, locale, children, inputRef }: DatePickerDialogProps) => {
+  const { state, dispatch } = useDatePickerContext();
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const position = state.dialogPosition;
+  const label = locale === 'ko' ? '날짜 선택' : 'Choose date';
+
+  useEffect(() => {
+    if (!state.isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+
+      dispatch({ type: 'SET_OPEN', open: false });
+      inputRef.current?.focus();
+    };
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+
+      if (contentRef.current?.contains(target) || inputRef.current?.contains(target)) {
+        return;
+      }
+
+      dispatch({ type: 'SET_OPEN', open: false });
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('mousedown', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handlePointerDown);
+    };
+  }, [dispatch, inputRef, state.isOpen]);
+
+  if (!state.isOpen || typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      ref={contentRef}
+      id={id}
+      role="dialog"
+      aria-label={label}
+      aria-modal="false"
+      data-state="open"
+      className="fixed z-201 overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none data-[state=closed]:animate-select-dialog-out data-[state=open]:animate-select-dialog-in dark:bg-(--color-card)"
+      style={position ? { top: position.y, left: position.x } : undefined}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+};

--- a/packages/gocheok-project/src/components/forms/datepicker/DatePickerTrigger.tsx
+++ b/packages/gocheok-project/src/components/forms/datepicker/DatePickerTrigger.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import React, { useLayoutEffect, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { useDatePickerContext } from '@gocheok/components/forms/datepicker/DatePickerContext';
+import type { DatePickerValue } from '@gocheok/components/forms/datepicker/types';
+import {
+  formatDate,
+  parseStrict,
+  startOfMonth,
+} from '@gocheok/components/forms/datepicker/utils/date';
+
+type DatePickerTriggerProps = {
+  dialogId: string;
+  format: string;
+  locale: string;
+  placeholder?: string;
+  id?: string;
+  name?: string;
+  disabled?: boolean;
+  required?: boolean;
+  className?: string;
+  ref?: React.Ref<HTMLInputElement>;
+  inputRef: React.MutableRefObject<HTMLInputElement | null>;
+  isDateAllowed: (date: Date) => boolean;
+  onCommit: (next: DatePickerValue) => void;
+};
+
+export const DatePickerTrigger = ({
+  dialogId,
+  format,
+  locale,
+  placeholder,
+  id,
+  name,
+  disabled,
+  required,
+  className,
+  ref,
+  inputRef,
+  isDateAllowed,
+  onCommit,
+}: DatePickerTriggerProps) => {
+  const { state, dispatch } = useDatePickerContext();
+  const [inputText, setInputText] = useState(() =>
+    state.value == null ? '' : formatDate(state.value, format, locale),
+  );
+  const [isEditing, setIsEditing] = useState(false);
+  const displayValue = isEditing
+    ? inputText
+    : state.value == null
+      ? ''
+      : formatDate(state.value, format, locale);
+
+  const setInputRef = (node: HTMLInputElement | null) => {
+    inputRef.current = node;
+
+    if (typeof ref === 'function') {
+      ref(node);
+    } else if (ref != null) {
+      // React ref 객체는 런타임에서만 갱신 (props 재할당이 아님)
+      ref.current = node;
+    }
+  };
+
+  const restoreValueText = () => {
+    setInputText(state.value == null ? '' : formatDate(state.value, format, locale));
+    setIsEditing(false);
+  };
+
+  const commitInputText = () => {
+    const trimmed = displayValue.trim();
+
+    if (trimmed.length === 0) {
+      onCommit(null);
+      setInputText('');
+      setIsEditing(false);
+      return;
+    }
+
+    const parsed = parseStrict(trimmed, format);
+
+    if (parsed == null || !isDateAllowed(parsed)) {
+      restoreValueText();
+      return;
+    }
+
+    onCommit(parsed);
+    setInputText(formatDate(parsed, format, locale));
+    setIsEditing(false);
+    dispatch({ type: 'SET_VISIBLE_MONTH', date: startOfMonth(parsed) });
+    dispatch({ type: 'SET_FOCUSED_DATE', date: parsed });
+  };
+
+  useLayoutEffect(() => {
+    if (!state.isOpen || inputRef.current == null) return;
+
+    const updatePosition = () => {
+      if (inputRef.current == null) return;
+
+      const { x, y, height } = inputRef.current.getBoundingClientRect();
+      const margin = 4;
+      const viewportPadding = 8;
+      const estimatedPopupWidth = 320;
+      const maxX = Math.max(
+        viewportPadding,
+        window.innerWidth - estimatedPopupWidth - viewportPadding,
+      );
+      const nextX = Math.min(Math.max(x, viewportPadding), maxX);
+
+      dispatch({
+        type: 'SET_DIALOG_POSITION',
+        position: { x: nextX, y: y + height + margin },
+      });
+    };
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [dispatch, inputRef, state.isOpen]);
+
+  const handleOpen = () => {
+    if (disabled) return;
+
+    dispatch({ type: 'SET_OPEN', open: true });
+  };
+
+  const handleToggle = () => {
+    if (disabled) return;
+
+    dispatch({ type: 'SET_OPEN', open: !state.isOpen });
+  };
+
+  return (
+    <div className={twMerge('relative w-full', className)}>
+      <input
+        ref={setInputRef}
+        role="combobox"
+        aria-controls={dialogId}
+        aria-expanded={state.isOpen}
+        aria-haspopup="dialog"
+        className={twMerge(
+          'w-full rounded-md border border-gray-300 bg-(--color-background) px-4 py-2 pr-10 text-(--color-foreground)',
+          'focus-visible:ring-2 focus-visible:ring-(--color-primary) focus-visible:outline-none',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+          !disabled && 'transition-colors duration-200 ease-in-out hover:border-(--color-primary)',
+        )}
+        disabled={disabled}
+        id={id}
+        name={name}
+        placeholder={placeholder}
+        required={required}
+        value={displayValue}
+        onBlur={commitInputText}
+        onChange={(event) => {
+          setIsEditing(true);
+          setInputText(event.target.value);
+        }}
+        onClick={handleOpen}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            commitInputText();
+          }
+
+          if (event.key === 'Escape') {
+            dispatch({ type: 'SET_OPEN', open: false });
+          }
+        }}
+      />
+      <button
+        type="button"
+        aria-label={state.isOpen ? '달력 닫기' : '달력 열기'}
+        className="absolute top-1/2 right-2 inline-flex size-8 -translate-y-1/2 items-center justify-center rounded-md text-(--color-grey-500) transition-colors duration-200 ease-in-out hover:bg-(--color-grey-100) disabled:cursor-not-allowed disabled:opacity-60"
+        disabled={disabled}
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={handleToggle}
+      >
+        <svg aria-hidden="true" className="size-4" fill="none" viewBox="0 0 24 24">
+          <path
+            d="M7 3v3M17 3v3M4 9h16M6 5h12a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Z"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.8"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+};

--- a/packages/gocheok-project/src/components/forms/datepicker/index.ts
+++ b/packages/gocheok-project/src/components/forms/datepicker/index.ts
@@ -1,0 +1,2 @@
+export * from '@gocheok/components/forms/datepicker/DatePicker';
+export * from '@gocheok/components/forms/datepicker/types';

--- a/packages/gocheok-project/src/components/forms/datepicker/types.ts
+++ b/packages/gocheok-project/src/components/forms/datepicker/types.ts
@@ -1,0 +1,36 @@
+import type React from 'react';
+
+export type DatePickerValue = Date | null;
+
+export interface DatePickerProps {
+  /** 제어 컴포넌트로 쓸 때 사용. `null`은 비어 있음. */
+  value?: DatePickerValue;
+  /** 비제어 초기값. `value`와 동시 사용 금지. */
+  defaultValue?: DatePickerValue;
+  /** 사용자가 날짜를 선택/지웠을 때 호출. 파싱 실패 시 `null` 전달. */
+  onChange?: (next: DatePickerValue) => void;
+  /** 입력 포맷. dayjs 토큰 (예: 'YYYY-MM-DD'). 기본값은 'YYYY-MM-DD'. */
+  format?: string;
+  /** 선택 가능한 최소/최대 날짜 (포함). */
+  minDate?: Date;
+  maxDate?: Date;
+  /** 특정 날짜 비활성화. 반환값이 true면 비활성. */
+  isDateDisabled?: (date: Date) => boolean;
+  /** 주 시작 요일 (0=일, 1=월). 기본 0. */
+  weekStartsOn?: 0 | 1;
+  /** dayjs locale 키. 기본 'ko'. */
+  locale?: string;
+  /** 이전/다음 월 이동 버튼에 표시할 아이콘. */
+  previousMonthIcon?: React.ReactNode;
+  nextMonthIcon?: React.ReactNode;
+  /** placeholder, id, name, disabled, required는 input에 그대로 전달. */
+  placeholder?: string;
+  id?: string;
+  name?: string;
+  disabled?: boolean;
+  required?: boolean;
+  /** 트리거 버튼/입력 컨테이너 className. */
+  className?: string;
+  /** input ref (React 19 ref-as-prop 컨벤션). */
+  ref?: React.Ref<HTMLInputElement>;
+}

--- a/packages/gocheok-project/src/components/forms/datepicker/utils/date.test.ts
+++ b/packages/gocheok-project/src/components/forms/datepicker/utils/date.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addDays,
+  addMonths,
+  buildMonthMatrix,
+  clampDate,
+  formatDate,
+  isSameDay,
+  isSameMonth,
+  parseStrict,
+  startOfMonth,
+} from '@gocheok/components/forms/datepicker/utils/date';
+
+describe('datepicker date utils', () => {
+  it('parses a valid date with strict format', () => {
+    const parsed = parseStrict('2026-04-26', 'YYYY-MM-DD');
+
+    expect(parsed).toEqual(new Date(2026, 3, 26));
+  });
+
+  it('returns null for invalid strict input', () => {
+    expect(parseStrict('2026-13-01', 'YYYY-MM-DD')).toBeNull();
+    expect(parseStrict('2026-4-26', 'YYYY-MM-DD')).toBeNull();
+  });
+
+  it('formats a date with locale', () => {
+    expect(formatDate(new Date(2026, 3, 26), 'YYYY-MM-DD', 'ko')).toBe('2026-04-26');
+  });
+
+  it('compares dates by day and month', () => {
+    expect(isSameDay(new Date(2026, 3, 26, 9), new Date(2026, 3, 26, 18))).toBe(true);
+    expect(isSameDay(new Date(2026, 3, 26), new Date(2026, 3, 27))).toBe(false);
+    expect(isSameMonth(new Date(2026, 3, 1), new Date(2026, 3, 30))).toBe(true);
+  });
+
+  it('moves dates by month and day', () => {
+    expect(startOfMonth(new Date(2026, 3, 26))).toEqual(new Date(2026, 3, 1));
+    expect(addMonths(new Date(2026, 3, 26), 1)).toEqual(new Date(2026, 4, 26));
+    expect(addDays(new Date(2026, 3, 26), -7)).toEqual(new Date(2026, 3, 19));
+  });
+
+  it('clamps dates to min and max by day', () => {
+    const min = new Date(2026, 3, 10);
+    const max = new Date(2026, 3, 20);
+
+    expect(clampDate(new Date(2026, 3, 1), min, max)).toEqual(min);
+    expect(clampDate(new Date(2026, 3, 30), min, max)).toEqual(max);
+    expect(clampDate(new Date(2026, 3, 15), min, max)).toEqual(new Date(2026, 3, 15));
+  });
+
+  it('builds a 6 by 7 month matrix with sunday start', () => {
+    const matrix = buildMonthMatrix({
+      visibleMonth: new Date(2026, 3, 26),
+      weekStartsOn: 0,
+    });
+
+    expect(matrix).toHaveLength(6);
+    expect(matrix.every((week) => week.length === 7)).toBe(true);
+    expect(matrix[0][0]).toEqual(new Date(2026, 2, 29));
+    expect(matrix[5][6]).toEqual(new Date(2026, 4, 9));
+  });
+
+  it('builds a month matrix with monday start', () => {
+    const matrix = buildMonthMatrix({
+      visibleMonth: new Date(2026, 3, 26),
+      weekStartsOn: 1,
+    });
+
+    expect(matrix[0][0]).toEqual(new Date(2026, 2, 30));
+    expect(matrix[5][6]).toEqual(new Date(2026, 4, 10));
+  });
+});

--- a/packages/gocheok-project/src/components/forms/datepicker/utils/date.ts
+++ b/packages/gocheok-project/src/components/forms/datepicker/utils/date.ts
@@ -1,0 +1,70 @@
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import localeData from 'dayjs/plugin/localeData';
+
+import 'dayjs/locale/ko';
+
+dayjs.extend(customParseFormat);
+dayjs.extend(localeData);
+
+export const parseStrict = (input: string, format: string): Date | null => {
+  const parsed = dayjs(input, format, true);
+
+  return parsed.isValid() ? parsed.toDate() : null;
+};
+
+export const formatDate = (date: Date, format: string, locale = 'ko'): string => {
+  return dayjs(date).locale(locale).format(format);
+};
+
+export const isSameDay = (a: Date, b: Date): boolean => {
+  return dayjs(a).isSame(b, 'day');
+};
+
+export const isSameMonth = (a: Date, b: Date): boolean => {
+  return dayjs(a).isSame(b, 'month');
+};
+
+export const startOfMonth = (date: Date): Date => {
+  return dayjs(date).startOf('month').toDate();
+};
+
+export const addMonths = (date: Date, count: number): Date => {
+  return dayjs(date).add(count, 'month').toDate();
+};
+
+export const addDays = (date: Date, count: number): Date => {
+  return dayjs(date).add(count, 'day').toDate();
+};
+
+export const clampDate = (date: Date, min?: Date, max?: Date): Date => {
+  const value = dayjs(date);
+
+  if (min != null && value.isBefore(min, 'day')) {
+    return dayjs(min).toDate();
+  }
+
+  if (max != null && value.isAfter(max, 'day')) {
+    return dayjs(max).toDate();
+  }
+
+  return value.toDate();
+};
+
+export const buildMonthMatrix = ({
+  visibleMonth,
+  weekStartsOn,
+}: {
+  visibleMonth: Date;
+  weekStartsOn: 0 | 1;
+}): Date[][] => {
+  const firstDayOfMonth = dayjs(startOfMonth(visibleMonth));
+  const dayOffset = (firstDayOfMonth.day() - weekStartsOn + 7) % 7;
+  const gridStart = firstDayOfMonth.subtract(dayOffset, 'day');
+
+  return Array.from({ length: 6 }, (_, weekIndex) =>
+    Array.from({ length: 7 }, (_day, dayIndex) =>
+      gridStart.add(weekIndex * 7 + dayIndex, 'day').toDate(),
+    ),
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
+  date:
+    dayjs:
+      specifier: ^1.11.13
+      version: 1.11.19
   react:
     '@types/node':
       specifier: ^24.0.1
@@ -557,6 +561,9 @@ importers:
       '@tailwindcss/vite':
         specifier: catalog:tailwindcss
         version: 4.1.10(vite@5.4.19(@types/node@24.10.1)(lightningcss@1.30.1)(sass@1.89.2)(terser@5.44.1))
+      dayjs:
+        specifier: catalog:date
+        version: 1.11.19
       gsap:
         specifier: ^3.13.0
         version: 3.13.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,3 +24,6 @@ catalogs:
     tailwind-merge: ^3.3.1
     "@tailwindcss/postcss": ^4.1.10
     "@tailwindcss/vite": ^4.1.10
+
+  date:
+    dayjs: ^1.11.13


### PR DESCRIPTION
## Summary
- gocheok-project에 DatePicker 컴포넌트와 popover 형태의 캘린더 UI를 추가했습니다.
- dayjs 기반 날짜 유틸, 단위 테스트, Storybook 예시와 public export를 연결했습니다.
- 월 이동 아이콘은 기본 SVG를 제공하고 `previousMonthIcon`/`nextMonthIcon`으로 교체할 수 있게 했습니다.

## Test plan
- [x] `pnpm --filter gocheok-project exec vitest run src/components/forms/datepicker/utils/date.test.ts`
- [x] `pnpm --filter gocheok-project run lint`
- [x] `pnpm --filter gocheok-project run build`

Refs #52

Made with [Cursor](https://cursor.com)